### PR TITLE
Add SALib to requirements during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'Click>=6.0',
+    'SALib',
     # TODO: put package requirements here
 ]
 


### PR DESCRIPTION
Hey Bart, this is a very small change to the setup to install `SALib` automatically with a `python setup.py` or `pip install -e` 