### PR TITLE
Bugfix: Add default for ti_array in calc_floris_approx_table

### DIFF
--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -397,6 +397,11 @@ def calc_floris_approx_table(
     ti_array=None,
     ):
 
+    # if ti_array is None, use the current value in the FLORIS object
+    if ti_array is None:
+        ti = fi.floris.flow_field.turbulence_intensity
+        ti_array = np.array([ti], dtype=float)
+
     fi = fi.copy()  # Create independent copy that we can manipulate
     num_turbines = len(fi.layout_x)
 

--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -392,8 +392,8 @@ def interpolate_floris_from_df_approx(
 
 def calc_floris_approx_table(
     fi,
-    wd_array=np.arange(0., 360., 1.0),
-    ws_array=np.arange(0., 20., 0.5),
+    wd_array=np.arange(0.0, 360.0, 1.0),
+    ws_array=np.arange(0.001, 25.001, 1.0),
     ti_array=None,
     ):
 

--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -393,7 +393,7 @@ def interpolate_floris_from_df_approx(
 def calc_floris_approx_table(
     fi,
     wd_array=np.arange(0.0, 360.0, 1.0),
-    ws_array=np.arange(0.001, 25.001, 1.0),
+    ws_array=np.arange(0.001, 26.001, 1.0),
     ti_array=None,
     ):
 

--- a/flasc/visualization.py
+++ b/flasc/visualization.py
@@ -23,7 +23,7 @@ def plot_with_wrapping(
     high=360.0,
     linestyle="-",
     marker=None,
-    color="black",
+    color=None,
     label=None
 ):
     """Plot a line on an axis that deals with angle wrapping. Normally, using
@@ -71,6 +71,10 @@ def plot_with_wrapping(
     # Create figure, if not provided
     if ax is None:
         fig, ax = plt.subplots()
+
+    if color is None:
+        # Use matplotlib's internal color cycler
+        color = ax._get_lines.prop_cycler.__next__()['color']
 
     if (low >= high):
         raise UserWarning("'low' must be lower than 'high'.")


### PR DESCRIPTION
Issue #12 demonstrates that `calc_floris_approx_table` in floris_tools currently fails when no value for `ti_array` is specified. Problem can be reproduced by:

```
import os
from floris.tools.floris_interface import FlorisInterface
from flasc import floris_tools as ftls


if __name__ == "__main__":
    file_path = os.path.dirname(os.path.abspath(__file__))
    fi_path = os.path.join(file_path, "demo_floris_input.yaml")
    fi = FlorisInterface(fi_path)
    df_approx = ftls.calc_floris_approx_table(fi)
    print(df_approx)
```

and yields the error:
```
Exception has occurred: AxisError
axis -1 is out of bounds for array of dimension 0
  File "/home/bartdoekemeijer/python_scripts/flasc/flasc/floris_tools.py", line 406, in calc_floris_approx_table
    ti_array = np.sort(ti_array)
  File "/home/bartdoekemeijer/python_scripts/flasc/examples/demo_dataset/tmp.py", line 14, in <module>
    df_approx = ftls.calc_floris_approx_table(fi)
```


This pull request solves the issue by defaulting to the current floris object's turbulence intensity when `ti_array` is `None`.