### PR TITLE
Bugfix: Deal with inconsistent pd.datetime and np.datetime64 formats

### DIFF
--- a/flasc/optimization.py
+++ b/flasc/optimization.py
@@ -53,8 +53,12 @@ def find_timeshift_between_dfs(
         raise NotImplementedError("Incompatible input specified.")
 
     # Get min and max time for dataframes
-    min_time = np.max([df1.head(1)["time"], df2.head(1)["time"]])
-    max_time = np.min([df1.tail(1)["time"], df2.tail(1)["time"]])
+    min_time = np.datetime64(
+        np.max([df1.head(1)["time"], df2.head(1)["time"]])
+    )
+    max_time = np.datetime64(
+        np.min([df1.tail(1)["time"], df2.tail(1)["time"]])
+    )
 
     # Convert to arrays of a single mean quantity
     print('Determining one column-average per dataframe to sync.')


### PR DESCRIPTION
Issue #11 demonstrates an inconsistency and error in the examples when comparing `pd.Timestamp` variables with `np.datetime64`. @ChristianBurth explains in #11 that

>  pd.Timestamp objects generally have a reference to a timezone, while np.datetime64 objects do not.

Hence, we resolve this by converting `pd.Timestamp` objects to `np.datetime64` prior to comparing the variables.