### PR TITLE
Add names to gui

### DIFF
--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 from floris import tools as wfct
 
 
-def plot(energy_ratios, labels=None):
+def plot(energy_ratios, labels=None, label_uq=False):
     """This function plots energy ratios against the reference wind
     direction. The plot may or may not include uncertainty bounds,
     depending on the information contained in the provided energy ratio
@@ -59,6 +59,9 @@ def plot(energy_ratios, labels=None):
         uq_labels = ["Confidence bounds" for _ in energy_ratios]
     else:
         uq_labels = ["%s confidence bounds" % lb for lb in labels]
+
+    if not label_uq:
+        uq_labels = ['_nolegend_' for l in uq_labels]
 
     N = len(energy_ratios)
     fig, ax = plt.subplots(nrows=2, sharex=True, figsize=(10, 5))

--- a/flasc/raw_data_handling/sqldatabase_management.py
+++ b/flasc/raw_data_handling/sqldatabase_management.py
@@ -100,9 +100,10 @@ class sql_database_manager:
             print("    N.o. columns: %d." % len(cols))
         print("")
 
-    def launch_gui(self):
+    def launch_gui(self, turbine_names=None):
         root = tk.Tk()
-        sql_db_explorer_gui(master=root, dbc=self)
+
+        sql_db_explorer_gui(master=root, dbc=self, turbine_names=turbine_names)
         root.mainloop()
 
     def get_column_names(self, table_name):
@@ -256,7 +257,7 @@ class sql_database_manager:
 
 
 class sql_db_explorer_gui:
-    def __init__(self, master, dbc):
+    def __init__(self, master, dbc, turbine_names = None):
 
         # Create the options container
         frame_1 = tk.Frame(master)
@@ -408,6 +409,9 @@ class sql_db_explorer_gui:
         # Set up the database connection
         self.dbc = dbc
 
+        # Save the turbine names
+        self.turbine_names = turbine_names
+
     def channel_add(self):
         if self.N_channels < self.N_channels_max:
             ci = self.N_channels  # New channel
@@ -463,6 +467,14 @@ class sql_db_explorer_gui:
                 ]
                 col_mapping = dict(zip(old_col_names, new_col_names))
                 df = df.rename(columns=col_mapping)
+
+                # If specific turbine names are supplied apply them here
+                if self.turbine_names is not None:
+                    columns = df.columns
+                    for t in range(len(self.turbine_names)):
+                        columns = [c.replace('%03d' % t,self.turbine_names[t]) for c in columns]
+                    df.columns = columns
+
                 df_array.append(df)
 
         # Merge dataframes


### PR DESCRIPTION
Ready to be merged

**Feature or improvement description**
This code adds an optional feature that allows naming the turbines in the database explorer GUI (rather than simple 0-indexed list)

Should not impact any existing functionality