### PR TITLE
change DataError from core.base to pandas.errors

### DIFF
--- a/examples/_legacy/sensitivity_analysis/simple_sobol_example.py
+++ b/examples/_legacy/sensitivity_analysis/simple_sobol_example.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 import floris.tools as wfct
 from floris.logging_manager import configure_console_log
-from pandas.core.base import DataError
+from pandas.errors import DataError
 
 from flasc import floris_sensitivity_analysis as fsasa
 

--- a/flasc/dataframe_operations/dataframe_filtering.py
+++ b/flasc/dataframe_operations/dataframe_filtering.py
@@ -92,7 +92,7 @@ def plot_highlight_data_by_conds(df, conds, ti):
         conds = [conds]
 
     # Convert time arrays to a string with 'year+week'
-    tfull = [int('%04d%02d' % (i.year, i.week)) for i in df.time]
+    tfull = [int('%04d%02d' % (i.isocalendar().year, i.isocalendar().week)) for i in df.time]
     time_array = np.unique(tfull)
 
     # Get number of non-NaN entries before filtering
@@ -113,7 +113,7 @@ def plot_highlight_data_by_conds(df, conds, ti):
         # Convert time array of occurrences to year+week no.
         conds_new = conds[ii] & (~conds_combined)
         conds_combined = (conds_combined | np.array(conds[ii], dtype=bool))
-        subset_time_array = [int('%04d%02d' % (i.year, i.week)) for i in df.loc[conds_new, 'time']]
+        subset_time_array = [int('%04d%02d' % (i.isocalendar().year, i.isocalendar().week)) for i in df.loc[conds_new, 'time']]
 
         for iii in range(len(time_array)):
             # Count occurrences for condition

--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 
 from floris.utilities import wrap_360
-from pandas.core.base import DataError
+from pandas.errors import DataError
 
 from ..dataframe_operations import dataframe_manipulations as dfm
 from ..energy_ratio import energy_ratio_visualization as ervis

--- a/flasc/energy_ratio/energy_ratio_suite.py
+++ b/flasc/energy_ratio/energy_ratio_suite.py
@@ -13,7 +13,7 @@
 
 import numpy as np
 import pandas as pd
-from pandas.core.base import DataError
+from pandas.errors import DataError
 from scipy.interpolate import NearestNDInterpolator
 
 from ..energy_ratio import energy_ratio as er

--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -15,7 +15,7 @@ from copy import deepcopy as dcopy
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from pandas.core.base import DataError
+from pandas.errors import DataError
 from scipy import interpolate
 from time import perf_counter as timerpc
 

--- a/flasc/model_estimation/floris_sensitivity_analysis.py
+++ b/flasc/model_estimation/floris_sensitivity_analysis.py
@@ -18,7 +18,7 @@ import pandas as pd
 from SALib.sample import saltelli
 from SALib.analyze import sobol
 
-from pandas.core.base import DataError
+from pandas.errors import DataError
 
 from .. import floris_tools as ftools
 

--- a/flasc/optimization.py
+++ b/flasc/optimization.py
@@ -14,7 +14,7 @@
 import copy
 from datetime import timedelta as td
 import numpy as np
-from pandas.core.base import DataError
+from pandas.errors import DataError
 import scipy.optimize as opt
 import scipy.stats as spst
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 openoa
 numpy
 numba
-pandas>=1.4.3
+pandas>=1.5
 pyproj
 pytest
 SALib

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRED = [
     'numpy',
     'numba',
     'openoa',
-    'pandas>=1.4.3',
+    'pandas>=1.5',
     'pyproj',
     'pytest',
     'SALib',

--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from pandas.core.base import DataError
+from pandas.errors import DataError
 
 import unittest
 from flasc.optimization import (


### PR DESCRIPTION
I believe ready to be merged

**Feature or improvement description**
I recently had an error that the DataError class was not a member of core.base and found it instead in pandas.errors, maybe this is just something that changed in pandas versions?  I'm running 1.4.4

@Bartdoekemeijer  does this change make any trouble for you?