### PR TITLE
Use isocalendar() to avoid error in year/week

### DIFF
--- a/flasc/dataframe_operations/dataframe_filtering.py
+++ b/flasc/dataframe_operations/dataframe_filtering.py
@@ -92,7 +92,7 @@ def plot_highlight_data_by_conds(df, conds, ti):
         conds = [conds]
 
     # Convert time arrays to a string with 'year+week'
-    tfull = [int('%04d%02d' % (i.year, i.week)) for i in df.time]
+    tfull = [int('%04d%02d' % (i.isocalendar().year, i.isocalendar().week)) for i in df.time]
     time_array = np.unique(tfull)
 
     # Get number of non-NaN entries before filtering
@@ -113,7 +113,7 @@ def plot_highlight_data_by_conds(df, conds, ti):
         # Convert time array of occurrences to year+week no.
         conds_new = conds[ii] & (~conds_combined)
         conds_combined = (conds_combined | np.array(conds[ii], dtype=bool))
-        subset_time_array = [int('%04d%02d' % (i.year, i.week)) for i in df.loc[conds_new, 'time']]
+        subset_time_array = [int('%04d%02d' % (i.isocalendar().year, i.isocalendar().week)) for i in df.loc[conds_new, 'time']]
 
         for iii in range(len(time_array)):
             # Count occurrences for condition


### PR DESCRIPTION
Is ready to merge

**Feature or improvement description**
Working on a project recently I had a strange issue where the year/week assignments plot_highlight_data_by_conds would get scrambled.  Posting the question to stack overflow:

https://stackoverflow.com/questions/73911825/how-does-datetime-understand-53rd-week/73912659#73912659

The resolution seems to be a deprecation of .week in favor of .isocalendar().week, so made that change here (don't see any other calls to .week in flasc currently)

This resolves the scrambling issue in my test, and you can see also the improvement in the little demo shown on stack link above.

Finally merging to core.base because I got somehow lapped and have those changes in my local develop.  Hopefully getting these things all merged up will untie some knots...