### PR TITLE
Make labeling UQ optional in energy ratio plot

### DIFF
--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -479,16 +479,20 @@ class energy_ratio:
         energy_ratios = df_summed.reset_index(drop=False)
         return energy_ratios
 
-    def plot_energy_ratio(self):
+    def plot_energy_ratio(self, hide_uq_labels=True):
         """This function plots the energy ratio against the wind direction,
         potentially with uncertainty bounds if N > 1 was specified by
         the user. One must first run get_energy_ratio() before attempting
         to plot the energy ratios.
 
+        Args:
+            hide_uq_labels (bool, optional): If true, do not specifically label
+                the confidence intervals in the plot
+
         Returns:
             ax [plt.Axes]: Axis handle for the figure.
         """
-        return ervis.plot(self.energy_ratio_out)
+        return ervis.plot(self.energy_ratio_out, hide_uq_labels=hide_uq_labels)
 
 
 # Support functions not included in energy_ratio class

--- a/flasc/energy_ratio/energy_ratio_suite.py
+++ b/flasc/energy_ratio/energy_ratio_suite.py
@@ -625,7 +625,7 @@ class energy_ratio_suite:
 
         return self.df_list
 
-    def plot_energy_ratios(self, superimpose=True):
+    def plot_energy_ratios(self, superimpose=True, hide_uq_labels=True):
         """This function plots the energy ratios of each dataset against
         the wind direction, potentially with uncertainty bounds if N > 1
         was specified by the user. One must first run get_energy_ratios()
@@ -636,6 +636,8 @@ class energy_ratio_suite:
             of all datasets into the same figure. If False, will plot the
             energy ratio of each dataset into a separate figure. Defaults
             to True.
+            hide_uq_labels (bool, optional): If true, do not specifically label
+            the confidence intervals in the plot
 
         Returns:
             ax [plt.Axes]: Axis handle for the figure.
@@ -643,12 +645,12 @@ class energy_ratio_suite:
         if superimpose:
             results_array = [df["er_results"] for df in self.df_list]
             labels_array = [df["name"] for df in self.df_list]
-            fig, ax = vis.plot(results_array, labels_array)
+            fig, ax = vis.plot(results_array, labels_array, hide_uq_labels=hide_uq_labels)
 
         else:
             ax = []
             for df in self.df_list:
-                fig, axi = vis.plot(df["er_results"], df["name"])
+                fig, axi = vis.plot(df["er_results"], df["name"], hide_uq_labels=hide_uq_labels)
                 ax.append(axi)
 
         return ax

--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 from floris import tools as wfct
 
 
-def plot(energy_ratios, labels=None, label_uq=False):
+def plot(energy_ratios, labels=None, hide_uq_labels=True):
     """This function plots energy ratios against the reference wind
     direction. The plot may or may not include uncertainty bounds,
     depending on the information contained in the provided energy ratio
@@ -43,6 +43,8 @@ def plot(energy_ratios, labels=None, label_uq=False):
                         with UQ.
         labels ([iteratible], optional): Label for each of the energy ratio
             dataframes. Defaults to None.
+        hide_uq_labels (boolean, optional): If true, do not specifically label
+            the confidence intervals in the plot
 
     Returns:
         fig ([plt.Figure]): Figure in which energy ratios are plotted.
@@ -60,7 +62,7 @@ def plot(energy_ratios, labels=None, label_uq=False):
     else:
         uq_labels = ["%s confidence bounds" % lb for lb in labels]
 
-    if not label_uq:
+    if hide_uq_labels:
         uq_labels = ['_nolegend_' for l in uq_labels]
 
     N = len(energy_ratios)

--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 from floris import tools as wfct
 
 
-def plot(energy_ratios, labels=None):
+def plot(energy_ratios, labels=None, label_uq=False):
     """This function plots energy ratios against the reference wind
     direction. The plot may or may not include uncertainty bounds,
     depending on the information contained in the provided energy ratio
@@ -59,6 +59,9 @@ def plot(energy_ratios, labels=None):
         uq_labels = ["Confidence bounds" for _ in energy_ratios]
     else:
         uq_labels = ["%s confidence bounds" % lb for lb in labels]
+
+    if not label_uq:
+        uq_labels = ['_nolegend_' for l in uq_labels]
 
     N = len(energy_ratios)
     fig, ax = plt.subplots(nrows=2, sharex=True, figsize=(10, 5))

--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -43,7 +43,7 @@ def plot(energy_ratios, labels=None, hide_uq_labels=True):
                         with UQ.
         labels ([iteratible], optional): Label for each of the energy ratio
             dataframes. Defaults to None.
-        hide_uq_labels (boolean, optional): If true, do not specifically label
+        hide_uq_labels (bool, optional): If true, do not specifically label
             the confidence intervals in the plot
 
     Returns:


### PR DESCRIPTION
Is ready to be merged

**Feature or improvement description**
Make labeling UQ optional in energy ratio plot, with default set to False 

**Related issue, if one exists**
Issue #29 
