### PR TITLE
Feature/block bootstrap

### DIFF
--- a/examples/energy_ratio/energy_ratio_vs_wd_for_single_df.py
+++ b/examples/energy_ratio/energy_ratio_vs_wd_for_single_df.py
@@ -110,4 +110,19 @@ if __name__ == '__main__':
                     + "(N=50, 90% confidence interval)")
     plt.tight_layout()
 
+    # Get energy ratio with uncertainty quantification
+    # using N=10 bootstrap samples and block bootstrapping
+    era.get_energy_ratio(
+        test_turbines=[1],
+        wd_step=2.0,
+        ws_step=1.0,
+        wd_bin_width=3.0,
+        N=50,
+        block_bootstrapping=True
+    )
+    fig, ax = era.plot_energy_ratio()
+    ax[0].set_title("Energy ratios for turbine 001 with UQ "
+                    + "(N=10, Block Bootstrapping)")
+    plt.tight_layout()
+
     plt.show()

--- a/examples/energy_ratio/energy_ratio_vs_wd_for_single_df.py
+++ b/examples/energy_ratio/energy_ratio_vs_wd_for_single_df.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         test_turbines=[1],
         wd_step=2.0,
         ws_step=1.0,
-        wd_bin_width=3.0,
+        wd_bin_width=2.0,
     )
     fig, ax = era.plot_energy_ratio()
     ax[0].set_title("Energy ratios for turbine 001 without UQ")
@@ -101,13 +101,13 @@ if __name__ == '__main__':
         test_turbines=[1],
         wd_step=2.0,
         ws_step=1.0,
-        wd_bin_width=3.0,
-        N=50,
+        wd_bin_width=2.0,
+        N=20,
         percentiles=[5.0, 95.0]
     )
     fig, ax = era.plot_energy_ratio()
     ax[0].set_title("Energy ratios for turbine 001 with UQ "
-                    + "(N=50, 90% confidence interval)")
+                    + "(N=20, 90% confidence interval)")
     plt.tight_layout()
 
     # Get energy ratio with uncertainty quantification
@@ -116,13 +116,14 @@ if __name__ == '__main__':
         test_turbines=[1],
         wd_step=2.0,
         ws_step=1.0,
-        wd_bin_width=3.0,
-        N=50,
-        block_bootstrapping=True
+        wd_bin_width=2.0,
+        N=20,
+        percentiles=[5.0, 95.0],
+        num_blocks=20 # Resample over 20 blocks
     )
     fig, ax = era.plot_energy_ratio()
     ax[0].set_title("Energy ratios for turbine 001 with UQ "
-                    + "(N=10, Block Bootstrapping)")
+                    + "(N=20, Block Bootstrapping)")
     plt.tight_layout()
 
     plt.show()

--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -300,8 +300,8 @@ class energy_ratio:
         N=1,
         percentiles=[5.0, 95.0],
         return_detailed_output=False,
-        block_bootstrapping = False, 
-        num_blocks = 10
+        block_bootstrapping=False, 
+        num_blocks=10
     ):
         """This is the main function used to calculate the energy ratios
         for dataframe provided to the class during initialization. One
@@ -408,8 +408,8 @@ class energy_ratio:
             N=N,
             percentiles=percentiles,
             return_detailed_output=return_detailed_output,
-            block_bootstrapping = block_bootstrapping, 
-            num_blocks = num_blocks
+            block_bootstrapping=block_bootstrapping, 
+            num_blocks=num_blocks
         )
         if return_detailed_output:
             energy_ratios = out[0]
@@ -509,8 +509,8 @@ def _get_energy_ratios_all_wd_bins_bootstrapping(
     N=1,
     percentiles=[5.0, 95.0],
     return_detailed_output=False,
-    block_bootstrapping = False, 
-    num_blocks = 10
+    block_bootstrapping=False, 
+    num_blocks=10
 ):
     """Wrapper function that calculates the energy ratio for every wind
     direction bin in the provided dataframe. This function wraps around

--- a/flasc/energy_ratio/energy_ratio_suite.py
+++ b/flasc/energy_ratio/energy_ratio_suite.py
@@ -315,7 +315,6 @@ class energy_ratio_suite:
         percentiles=[5.0, 95.0],
         balance_bins_between_dfs=True,
         return_detailed_output=False,
-        block_bootstrapping=False, 
         num_blocks=10,
         verbose=True,
     ):
@@ -400,6 +399,10 @@ class energy_ratio_suite:
                 direction and wind speed bin, among others. This is
                 particularly helpful in figuring out if the bins are well
                 balanced. Defaults to False.
+            num_blocks (int, optional): Number of blocks to use in block
+                boostrapping.  If = -1 then don't use block bootstrapping
+                and follow normal approach of sampling num_samples randomly
+                with replacement.  Defaults to -1.
             verbose (bool, optional): Print to console. Defaults to True.
 
         Returns:
@@ -499,7 +502,6 @@ class energy_ratio_suite:
                 N=N,
                 percentiles=percentiles,
                 return_detailed_output=return_detailed_output,
-                block_bootstrapping = block_bootstrapping, 
                 num_blocks = num_blocks
             )
 

--- a/flasc/energy_ratio/energy_ratio_suite.py
+++ b/flasc/energy_ratio/energy_ratio_suite.py
@@ -315,8 +315,8 @@ class energy_ratio_suite:
         percentiles=[5.0, 95.0],
         balance_bins_between_dfs=True,
         return_detailed_output=False,
-        block_bootstrapping = False, 
-        num_blocks = 10,
+        block_bootstrapping=False, 
+        num_blocks=10,
         verbose=True,
     ):
         """This is the main function used to calculate the energy ratios

--- a/flasc/energy_ratio/energy_ratio_suite.py
+++ b/flasc/energy_ratio/energy_ratio_suite.py
@@ -315,6 +315,8 @@ class energy_ratio_suite:
         percentiles=[5.0, 95.0],
         balance_bins_between_dfs=True,
         return_detailed_output=False,
+        block_bootstrapping = False, 
+        num_blocks = 10,
         verbose=True,
     ):
         """This is the main function used to calculate the energy ratios
@@ -497,6 +499,8 @@ class energy_ratio_suite:
                 N=N,
                 percentiles=percentiles,
                 return_detailed_output=return_detailed_output,
+                block_bootstrapping = block_bootstrapping, 
+                num_blocks = num_blocks
             )
 
             # Save each output to self


### PR DESCRIPTION
is NOT ready to be merged

**Feature or improvement description**
This is a first draft implementation of block bootstrapping.  In our current bootstrapping, we sample all R rows from a dataframe with R totals rows (with replacement) N times.  In the proposed block bootstrapping method, the data are divided into D consecutive blocks (with the 0th block including any residual rows at the end), and we sample D of these blocks (with replacement) N times instead.   I think theory is roughly like:

https://en.wikipedia.org/wiki/Bootstrapping_(statistics)#Block_bootstrap

But essentially since we have 1/10 minute samples, these might relate a lot in time, so removing whole blocks from iterations could help to better show underlying uncertainty

I added a demonstration to the example: energy_ratio_vs_wd_for_single_df, but should work also with suite

**Related issue, if one exists**
Issue #39 
