### PR TITLE
Reinstate return_index_mapping in df_downsample

### DIFF
--- a/flasc/time_operations.py
+++ b/flasc/time_operations.py
@@ -288,10 +288,12 @@ def df_downsample(
         df_out.index = df_out.index - window_width / 2.0
 
     if return_index_mapping:
-        df_tmp = df[[]].copy().reset_index()
-        df_tmp["tmp"] = 1
-        df_tmp = df_tmp.resample(window_width, on="time", label="right", axis=0)["tmp"]
-
+        df_tmp = (pd.DataFrame(
+            data = {"time":df.reset_index()["time"],
+                    "tmp":1}
+            )
+            .resample(window_width, on="time", label="right", axis=0)
+        )["tmp"]
 
         # Grab index of first and last time entry for each window
         def get_first_index(x):

--- a/flasc/time_operations.py
+++ b/flasc/time_operations.py
@@ -293,7 +293,7 @@ def df_downsample(
                     "tmp":1}
             )
             .resample(window_width, on="time", label="right", axis=0)
-        )["tmp"]
+        )
 
         # Grab index of first and last time entry for each window
         def get_first_index(x):
@@ -307,8 +307,8 @@ def df_downsample(
             else:
                 return x.index[-1]
 
-        windows_min = list(df_tmp.apply(get_first_index).astype(int))
-        windows_max = list(df_tmp.apply(get_last_index).astype(int))
+        windows_min = df_tmp.apply(get_first_index)["tmp"].to_list()
+        windows_max = df_tmp.apply(get_last_index)["tmp"].to_list()
 
         # Now create a large array that contains the array of indices, with
         # the values in each row corresponding to the indices upon which that

--- a/tests/df_time_operations_test.py
+++ b/tests/df_time_operations_test.py
@@ -39,26 +39,30 @@ class TestDataFrameResampling(unittest.TestCase):
 #     if True:
     def test_downsampling(self):
         df = load_data()
-        df_ds = df_downsample(
+        df_ds, data_indices = df_downsample(
             df_in=df,
             cols_angular=["wd_000"],
             window_width=td(seconds=5),
             min_periods=1,
             center=True,
-            calc_median_min_max_std=True
+            calc_median_min_max_std=True,
+            return_index_mapping=True
         )
 
         # Check solutions: for first row
         self.assertAlmostEqual(df_ds.iloc[0]["ws_000_mean"], 7.10)
         self.assertAlmostEqual(df_ds.iloc[0]["ws_000_std"], 0.10)
         self.assertAlmostEqual(df_ds.iloc[0]["wd_000_std"], 2.625014, places=4)
+        self.assertTrue(np.all(np.unique(data_indices[0, :]) == [-1, 0, 1, 2]))
 
         # Check solutions: for big chunk of data in middle of dataframe (Nones)
         self.assertTrue(df_ds.drop(columns=["time"]).\
             iloc[4:11].isna().all().all())
+        self.assertTrue(np.all(np.unique(data_indices[4:11, :]) == [-1]))
 
         # Check solutions: for one but last row
         self.assertAlmostEqual(df_ds.iloc[-2]["ws_000_mean"], 7.0)
+        self.assertTrue(np.all(np.unique(data_indices[-2, :]) == [-1, 6]))
         self.assertTrue(np.isnan(df_ds.iloc[-2]["vane_000_std"]))
 
     def test_moving_average(self):


### PR DESCRIPTION
Recent updates to `df_downsample()` (in time_operations.py) removed functionality for providing information about which indices from the full resolution dataframe went into each index of the downsampled dataframe. This broke some functionality for some users. 

This bugfix addresses this issue by reinstating the `return_index_mapping` flag to return the `data_indices` output in `df_downsample()`. Note that, at this point, `df_movingaverage()` still does _not_ return `data_indices`, although the `return_index_mapping` flag remains an input option. This may be addressed in a future bug fix if needed. 

Bug is reported in issue #52. Change would close this issue.

Changes made to `df_downsample` and test code.