### PR TITLE
catch case of small number of points

### DIFF
--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -715,6 +715,10 @@ def _get_energy_ratio_single_wd_bin_bootstrapping(
         results_array = np.array([energy_ratio_nominal] * 3, dtype=float)
     else:
 
+        # First check, if num_blocks is > number of points, assign number of points
+        if num_blocks > df_binned.shape[0]:
+            num_blocks = df_binned.shape[0]
+
         # Check that num_blocks is an allowable number
         if (num_blocks < -1) or (num_blocks == 0) or (num_blocks == 1) or (num_blocks > df_binned.shape[0]):
             raise ValueError("num_blocks should either be -1 (don't use block bootstrapping) or else a number between 2 and num_samples")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
Yes

**Feature or improvement description**
Add check for small number of points in block bootstrapping (less than number of blocks) and in that case revert to using each point as block
