### PR TITLE
Bugfix/two small issues

### DIFF
--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -715,9 +715,12 @@ def _get_energy_ratio_single_wd_bin_bootstrapping(
         results_array = np.array([energy_ratio_nominal] * 3, dtype=float)
     else:
 
-        # First check, if num_blocks is > number of points, assign number of points
+        # First check, if num_blocks is > number of points, then assume normal bootstrapping
         if num_blocks > df_binned.shape[0]:
-            num_blocks = df_binned.shape[0]
+            num_blocks = -1
+
+        # If after this revision, the number of blocks is very low, use normal bootstrapping
+
 
         # Check that num_blocks is an allowable number
         if (num_blocks < -1) or (num_blocks == 0) or (num_blocks == 1) or (num_blocks > df_binned.shape[0]):

--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -68,7 +68,10 @@ def plot(energy_ratios, labels=None, colors=None, hide_uq_labels=True):
 
     # If colors is a list that contains None, assume colors not assigned
     if isinstance(colors, (list, tuple)):
+
         if None in colors:
+            if not all(v is None for v in colors):
+                print("It's possible some but not all colors are supplied, therefore reverting to defaults")
             colors = None
 
     N = len(energy_ratios)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
Yes, ready

**Feature or improvement description**
Found two small issues with block bootstrapping and using colors.  In the color case, if you supplied some but not all colors, the code quietly reverts to default colors, adding a warning now to explain.  In bootstrapping, for wd with just 1 point, this triggered an error and a better approach I think is just revert to normal bootstrapping whenever the number of blocks is more than the number of points (what happens effectively anyway)

Such small changes going to go ahead and merge directly