### PR TITLE
Fix NaN handling in calc_wd_mean_radial

### DIFF
--- a/flasc/circular_statistics.py
+++ b/flasc/circular_statistics.py
@@ -18,17 +18,19 @@ from floris.utilities import wrap_360
 
 def calc_wd_mean_radial(angles_array_deg, axis=0):
     
-    # Prevent calculation if all inputs are NaNs
-    if np.isnan(angles_array_deg).all():
-        return np.nan
+    # Generate mask for all NaN rows/columns
+    nan_mask = np.isnan(angles_array_deg).all(axis=axis)
     
     # Use unit vectors to calculate the mean
     wd_x = np.cos(angles_array_deg * np.pi / 180.)
     wd_y = np.sin(angles_array_deg * np.pi / 180.)
 
-    mean_wd = np.arctan2(np.sum(wd_y, axis=axis),
-                         np.sum(wd_x, axis=axis))
+    mean_wd = np.arctan2(np.nansum(wd_y, axis=axis),
+                         np.nansum(wd_x, axis=axis))
     mean_wd = wrap_360(mean_wd * 180. / np.pi)
+    
+    # Replace values based on all NaNs with NaN
+    mean_wd[nan_mask] = np.nan
 
     return mean_wd
 

--- a/flasc/circular_statistics.py
+++ b/flasc/circular_statistics.py
@@ -17,6 +17,11 @@ from floris.utilities import wrap_360
 
 
 def calc_wd_mean_radial(angles_array_deg, axis=0):
+    
+    # Prevent calculation if all inputs are NaNs
+    if np.isnan(angles_array_deg).all():
+        return np.nan
+    
     # Use unit vectors to calculate the mean
     wd_x = np.cos(angles_array_deg * np.pi / 180.)
     wd_y = np.sin(angles_array_deg * np.pi / 180.)


### PR DESCRIPTION
### Issue
`calc_wd_mean_radial()` produces some inconsistent behavior. When the `angles_array_deg` input is a numpy array that contains NaNs, the output mean wind direction is NaN. However, when `angles_array_deg` is a dataframe, with only a few NaN values, the output ignores the NaNs, and when `angles_array_deg` contains entire rows/columns of NaNs, the output is 0. 

### Solution
I propose the following approach:
- If some, but not all, wind directions in the mean are NaNs, those values are ignored and the mean is over the non-NaN values
- If all wind directions in the mean are NaNs, NaN is returned.

Note that this is slightly different than current behavior, which:
- returns NaN when any NaNs are present if `angles_array_deg` is a numpy array; and returns the mean over non-NaN values if `angles_array_deg` is a dataframe.
- returns NaN when all wind directions are NaN if `angles_array_deg` is a numpy array; and returns 0 when all wind directions are NaN if `angles_array_deg` is a dataframe.

### Steps to recreate issue

Run the following code on the current develop branch and compare to this bugfix branch:
```
from flasc import circular_statistics as cs
import numpy as np
import pandas as pd

print(np.nansum(np.array([3, 2, np.nan]))) # Intuitive
print(np.nansum(np.array([np.nan, np.nan, np.nan]))) # Not particularly intuitive

# generate data centered around 0
np.random.seed(1)
X = 360 + np.random.randn(5, 3)*5

## Behavior for numpy arrays

print(X)
# Normal behavior
print(cs.calc_wd_mean_radial(X))
print(cs.calc_wd_mean_radial(X, 1))

# Behavior when NaNs present
X_nans = X.copy()
X_nans[:,1] = np.nan
X_nans[1,:] = np.nan

print(X_nans)
# All nans due to presence of at least one nan
print(cs.calc_wd_mean_radial(X_nans)) 
print(cs.calc_wd_mean_radial(X_nans, 1)) 

## Behavior when data is a pandas dataframe
df = pd.DataFrame(X)

print(df)
# Runs as expected when NaNs not present
print(cs.calc_wd_mean_radial(df)) 
print(cs.calc_wd_mean_radial(df, 1)) 

df_nans = pd.DataFrame(X_nans)
print(df_nans)
# Runs as expected when not all values are NaN, but produces zeros when all 
# values are NaN
print(cs.calc_wd_mean_radial(df_nans)) 
print(cs.calc_wd_mean_radial(df_nans, 1)) 
```

I could also turn the above (or something similar) into a unit test for `calc_wd_mean_radial()`.