### PR TITLE
Code for determining which turbines impact the power of a given turbine

### DIFF
--- a/examples/layout/turbine_dependencies.py
+++ b/examples/layout/turbine_dependencies.py
@@ -24,6 +24,14 @@ print("Turbines that depend on T002 at 226 degrees:",
       depend_on_2[round(226/2)]
      )
 
+# Can also return all influences as a matrix for other use (not ordered)
+depend_on_2, influence_magnitudes = fsatools.get_dependent_turbines_by_wd(
+    fi, 2, check_directions, return_influence_magnitudes=True)
+print("\nArray of all influences of T002 has shape (num_wds x num_turbs): ", 
+      influence_magnitudes.shape)
+print("Influence of T002 on T006 at 226 degrees: {0:.4f}".format( 
+      influence_magnitudes[round(226/2), 6]))
+
 df_dependencies = fsatools.get_all_dependent_turbines(fi, check_directions)
 print("\nAll turbine dependencies using default threshold "+\
       "(first 5 wind directions printed):")

--- a/examples/layout/turbine_dependencies.py
+++ b/examples/layout/turbine_dependencies.py
@@ -6,6 +6,15 @@ from flasc import floris_tools as fsatools
 from flasc import visualization as fsaviz
 
 from floris import tools as wfct
+
+# Demonstrate the turbine dependency functions in floris_tools
+# Note a turbine is "dependent" on another if it is affected 
+# by the wake of the other turbine for a given wind direction.
+
+# A given turbine's dependent turbines are those that depend on it,
+# and a turbine's impacting turbines are those turbines that
+# it itself depends on.
+
     
 # Set up FLORIS interface
 print('Initializing the FLORIS object for our demo wind farm')

--- a/examples/layout/turbine_dependencies.py
+++ b/examples/layout/turbine_dependencies.py
@@ -1,0 +1,74 @@
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+
+from flasc import floris_tools as fsatools
+from flasc import visualization as fsaviz
+
+from floris import tools as wfct
+    
+# Set up FLORIS interface
+print('Initializing the FLORIS object for our demo wind farm')
+file_path = os.path.dirname(os.path.abspath(__file__))
+fi_path = os.path.join(file_path, '../demo_dataset/demo_floris_input.yaml')
+fi = wfct.floris_interface.FlorisInterface(fi_path)
+
+# Plot the layout of the farm for reference
+fsaviz.plot_layout_only(fi)
+
+# Get the dependencies of turbine 2
+check_directions = np.arange(0, 360., 2.)
+depend_on_2 = fsatools.get_dependent_turbines_by_wd(fi, 2, check_directions)
+
+print("Turbines that depend on T002 at 226 degrees:", 
+      depend_on_2[round(226/2)]
+     )
+
+df_dependencies = fsatools.get_all_dependent_turbines(fi, check_directions)
+print("\nAll turbine dependencies using default threshold "+\
+      "(first 5 wind directions printed):")
+print(df_dependencies.head())
+
+df_dependencies = fsatools.get_all_dependent_turbines(fi, check_directions, 
+    limit_number=2)
+print("\nTwo most significant turbine dependencies using default threshold "+\
+      "(first 5 wind directions printed):")
+print(df_dependencies.head())
+
+df_dependencies = fsatools.get_all_dependent_turbines(fi, check_directions, 
+    change_threshold=0.01)
+print("\nAll turbine dependencies using higher threshold "+\
+      "(first 5 wind directions printed):")
+print(df_dependencies.head())
+
+print("\nAll upstream turbine impacts using default threshold "+\
+      "(first 5 wind directions printed):")
+df_impacting = fsatools.get_all_impacting_turbines(fi, check_directions)
+print(df_impacting.head())
+# Inclusion of T005 here as an impact on T000 is surprising; try increasing
+# the threshold or reducing the limit_number (see next).
+
+print("\nMost significant upstream turbine impact using default threshold "+\
+      "(first 5 wind directions printed):")
+df_impacting = fsatools.get_all_impacting_turbines(fi, check_directions,
+    limit_number=1)
+print(df_impacting.head())
+
+print("\nAll upstream turbine impacts using higher threshold "+\
+      "(first 5 wind directions printed):")
+df_impacting = fsatools.get_all_impacting_turbines(fi, check_directions,
+    change_threshold=0.01)
+print(df_impacting.head())
+
+# Note that there is no individual turbine version for the "impacting" 
+# function; instead, compute all impacting turbines and extract desired 
+# turbine from the output dataframe.
+
+# (compute using defaults again, for example)
+df_impacting = fsatools.get_all_impacting_turbines(fi, check_directions)
+print("\nTurbines that T006 depends on at 226 degrees:", 
+      df_impacting.loc[226, 6]
+     )
+
+
+plt.show()

--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -672,7 +672,7 @@ def get_upstream_turbs_floris(fi, wd_step=0.1, wake_slope=0.10,
     return df_upstream
 
 def get_dependent_turbines_by_wd(fi_in, test_turbine, 
-    wd_array=np.arange(0., 360., 2.), change_threshold=0., limit_number=None, 
+    wd_array=np.arange(0., 360., 2.), change_threshold=0.001, limit_number=None, 
     ws_test=9., return_influence_magnitudes=False):
     """
     Computes all turbines that depend on the operation of a specified 
@@ -720,7 +720,11 @@ def get_dependent_turbines_by_wd(fi_in, test_turbine,
     base_power = fi.get_turbine_powers()[:,0,:] # remove unneeded dimension
     
     # Compute the test power
-    fi.floris.farm.turbine_type.pop(test_turbine) # Remove test turbine from list
+    if len(fi.floris.farm.turbine_type) > 1:
+        # Remove test turbine from list
+        fi.floris.farm.turbine_type.pop(test_turbine) 
+    else: # Only a single turbine type defined for the whole farm; do nothing
+        pass
     fi.reinitialize(
         layout_x=np.delete(fi.layout_x, [test_turbine]),
         layout_y=np.delete(fi.layout_y, [test_turbine]),
@@ -760,7 +764,7 @@ def get_dependent_turbines_by_wd(fi_in, test_turbine,
         return dep_indices_by_wd
 
 def get_all_dependent_turbines(fi_in, wd_array=np.arange(0., 360., 2.), 
-    change_threshold=0.0, limit_number=None, ws_test=9.):
+    change_threshold=0.001, limit_number=None, ws_test=9.):
     """
     Wrapper for get_dependent_turbines_by_wd() that loops over all 
     turbines in the farm and packages their dependencies as a pandas 
@@ -805,7 +809,7 @@ def get_all_dependent_turbines(fi_in, wd_array=np.arange(0., 360., 2.),
     return df_out
 
 def get_all_impacting_turbines(fi_in, wd_array=np.arange(0., 360., 2.), 
-    change_threshold=0.0, limit_number=None, ws_test=9.):
+    change_threshold=0.001, limit_number=None, ws_test=9.):
     """
     Calculate which turbines impact a specified turbine based on the 
     FLORIS model. Essentially a wrapper for 

--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -691,7 +691,7 @@ def get_dependent_turbines_by_wd(fi_in, test_turbine,
             turbine can have as dependencies. If None, returns all 
             turbines that depend on each turbine. Defaults to None.
         ws_test (float): Wind speed at which FLORIS model is run to 
-            determine dependencies.
+            determine dependencies.  Defaults to 9. m/s.
         return_influence_magnitudes (Bool): Flag for whether to return 
             an array containing the magnitude of the influence of the 
             test_turbine on all turbines.
@@ -781,7 +781,7 @@ def get_all_dependent_turbines(fi_in, wd_array=np.arange(0., 360., 2.),
             turbine can have as dependencies. If None, returns all 
             turbines that depend on each turbine. Defaults to None.
         ws_test (float): Wind speed at which FLORIS model is run to 
-            determine dependencies.
+            determine dependencies. Defaults to 9. m/s.
         
     Returns:
         df_out ([pd.DataFrame]): A Pandas Dataframe in which each row
@@ -827,7 +827,7 @@ def get_all_impacting_turbines(fi_in, wd_array=np.arange(0., 360., 2.),
             turbine can depend on. If None, returns all 
             turbines that each turbine depends on. Defaults to None.
         ws_test (float): Wind speed at which FLORIS model is run to 
-            determine dependencies.
+            determine dependencies. Defaults to 9. m/s.
 
     Returns:
         df_out ([pd.DataFrame]): A Pandas Dataframe in which each row

--- a/tests/floris_tools_test.py
+++ b/tests/floris_tools_test.py
@@ -5,7 +5,8 @@ import pandas as pd
 import unittest
 from flasc.floris_tools import (
     calc_floris_approx_table,
-    interpolate_floris_from_df_approx
+    interpolate_floris_from_df_approx,
+    get_dependent_turbines_by_wd
 )
 
 from floris import tools as wfct
@@ -68,3 +69,21 @@ class TestFlorisTools(unittest.TestCase):
         # self.assertTrue(("ti_002" in df.columns))
         self.assertTrue(("pow_003" in df.columns))
         self.assertAlmostEqual(df.shape[0], 3)
+
+    def test_get_dependent_turbines_by_wd(self):
+        # Load FLORIS object
+        fi = load_floris()
+
+        # compute the dependency on turbine 2 at 226 degrees
+        dep = get_dependent_turbines_by_wd(fi, 2, np.array([226]))
+        self.assertEqual(dep[0], [1, 6])
+
+        # Test the change_threshold
+        dep = get_dependent_turbines_by_wd(fi, 2, np.array([226]), 
+            change_threshold=0.01)
+        self.assertEqual(dep[0], [1])
+
+        # Test the limit_number
+        dep = get_dependent_turbines_by_wd(fi, 2, np.array([226]), 
+            limit_number=1)
+        self.assertEqual(dep[0], [1])


### PR DESCRIPTION
Ready for review and merge.

New functionality added to floris_tools.py to compute which turbines impact and depend on a specified turbine, based on their variations in power predicted by FLORIS.


Tasks:
- [x] Implement code to determine which turbines _impact_ a specified turbine
- [x] Implement code to determine which turbines _depend on_ a specified turbine
- [x] Implement wrappers for both of the above to run over all turbines [Note: _dependencies_ are available per turbine. _impacting turbines_ are available only as a full set, due to code structure]
- [x] Create example that shows usage
- [x] Create tests