### PR TITLE
Add data plot to visualization

### DIFF
--- a/examples/energy_ratio/wake_steering_example.py
+++ b/examples/energy_ratio/wake_steering_example.py
@@ -22,7 +22,8 @@ from floris.utilities import wrap_360
 from flasc.energy_ratio import energy_ratio_suite
 # from flasc import floris_tools as fsatools
 
-from flasc.visualization import plot_layout_with_waking_directions
+from flasc.visualization import plot_layout_with_waking_directions, plot_binned_mean_and_ci
+
 
 
 if __name__ == "__main__":
@@ -118,6 +119,15 @@ if __name__ == "__main__":
         'pow_001':power_wakesteering_control,
         'pow_002':power_wakesteering_downstream
     })
+
+    # Use the function plot_binned_mean_and_ci to show the noise in wind speed
+    fig, ax = plt.subplots(1,1,sharex=True)
+    plot_binned_mean_and_ci(df_baseline.ws, df_baseline_noisy.ws, ax=ax)
+    ax.set_xlabel('Wind Speed (m/s) [Baseline]')
+    ax.set_ylabel('Wind Speed (m/s) [Baseline (Noisy)]')
+    ax.grid(True)
+    
+
 
     # Make a color palette that visually links the nominal and noisy data sets together
     color_palette = sns.color_palette("Paired",4)[::-1]

--- a/flasc/visualization.py
+++ b/flasc/visualization.py
@@ -650,7 +650,7 @@ def plot_binned_mean_and_ci(
     show_bin_points=True,
     show_confidence=True,
     alpha_scatter=0.1,
-    confidenceLevel = 0.95,
+    confidence_level = 0.95,
 ):
     """
     Plot data to a single axis.  Method
@@ -721,11 +721,12 @@ def plot_binned_mean_and_ci(
     df_agg = df_agg[df_agg["y_count"] > 0]
 
     # Add the confidence interval of the mean to df_agg
-    df_agg["y_confidence"] = st.t.interval(confidenceLevel, 
-                                           df_agg["y_count"]-1,
-                                           loc=df_agg["y_mean"],
-                                            scale=df_agg["y_sem"])[1] - df_agg["y_mean"]
-
+    df_agg["y_ci_lower"], df_agg["y_ci_upper"] = st.t.interval(
+        confidence_level, 
+        df_agg["y_count"]-1,
+        loc=df_agg["y_mean"],
+        scale=df_agg["y_sem"]
+    )
 
     # Plot the mean values
     ax.plot(df_agg.x_bin, df_agg.y_mean, color=color, label=label)
@@ -734,8 +735,8 @@ def plot_binned_mean_and_ci(
     if show_confidence:
         ax.fill_between(
             df_agg.x_bin,
-            df_agg.y_mean - df_agg.y_confidence,
-            df_agg.y_mean + df_agg.y_confidence,
+            df_agg.y_ci_lower,
+            df_agg.y_ci_upper,
             color=color,
             alpha=0.2,
         )
@@ -743,14 +744,14 @@ def plot_binned_mean_and_ci(
         # Plot a dasshed line at confidence interval
         ax.plot(
             df_agg.x_bin,
-            df_agg.y_mean - df_agg.y_confidence,
+            df_agg.y_ci_lower,
             color=color,
             alpha=0.2,
             ls="--",
         )
         ax.plot(
             df_agg.x_bin,
-            df_agg.y_mean + df_agg.y_confidence,
+            df_agg.y_ci_upper,
             color=color,
             alpha=0.2,
             ls="--",

--- a/flasc/visualization.py
+++ b/flasc/visualization.py
@@ -699,7 +699,7 @@ def plot_binned_mean_and_ci(
 
     # If x_edges not provided, use 50 bins over range of x
     if x_edges is None:
-        x_edges = np.linspace(df["x"].min()*.95, df["x"].max()*1.05, 50)
+        x_edges = np.linspace(df["x"].min()*.98, df["x"].max()*1.02, 50)
 
     # Define x_labels as bin centers
     x_labels = (x_edges[1:] + x_edges[:-1]) / 2.0

--- a/flasc/visualization.py
+++ b/flasc/visualization.py
@@ -772,14 +772,3 @@ def plot_binned_mean_and_ci(
         )
 
     return ax
-    
-# Small little demo of data plot, can delete
-if __name__ == "__main__":
-
-    # Declare some test data
-    x = np.random.uniform(0, 1, 1000)
-    y = 2 * x + 1 + np.random.normal(0, 0.1, 1000)
-
-    plot_binned_mean_and_ci(x,y, show_scatter=True)
-
-    plt.show()

--- a/flasc/visualization.py
+++ b/flasc/visualization.py
@@ -13,6 +13,7 @@
 
 import numpy as np
 from matplotlib import pyplot as plt
+import pandas as pd
 
 
 def plot_with_wrapping(
@@ -639,12 +640,135 @@ def label_line(
 
 
 
+def data_plot(
+    x,
+    y,
+    color="b",
+    label="_nolegend_",
+    x_edges=None,
+    ax=None,
+    show_scatter=True,
+    show_bin_points=True,
+    show_confidence=True,
+    alpha_scatter=0.1,
+):
+    """
+    Plot data to a single axis.  Method
+    has options to include scatter of underlying data, specifiying
+    bin edges, and plotting confidence interval.
 
+    Args:
+        x (np.array): abscissa data.
+        y (np.array): ordinate data.
+        color (str, optional): line color.
+            Defaults to 'b'.
+        label (str, optional): line label used in legend.
+            Defaults to '_nolegend_'.
+        x_edges (np.array, optional): bin edges in x data
+            Defaults to None.
+        ax (:py:class:`matplotlib.pyplot.axes`, optional):
+            axes handle for plotting. Defaults to None.
+        show_scatter (bool, optional): flag to control scatter plot.
+            Defaults to True.
+        show_bin_points (bool, optional): flag to control plot of bins.
+            Defaults to True.
+        show_confidence (bool, optional): flag to control plot of
+            confidence interval. Defaults to True.
+        alpha_scatter (float, optional): Alpha for scatter
+            plot. Defaults to 0.5.
+
+    """
+
+    # Check the length of x equals length of y
+    if len(x) != len(y):
+        raise ValueError("x and y must be the same length")
     
+    # Check that x is not empty
+    if len(x) == 0:
+        raise ValueError("x is empty")
     
 
+    # Declare ax if not provided
+    if ax is None:
+        _, ax = plt.subplots()
+
+    # Put points ino dataframe
+    df = pd.DataFrame({"x": x, "y": y})
+
+    # If x_edges not provided, use 50 bins over range of x
+    if x_edges is None:
+        x_edges = np.linspace(df["x"].min(), df["x"].max(), 50)
+
+    # Define x_labels as bin centers
+    x_labels = (x_edges[1:] + x_edges[:-1]) / 2.0
+
+    # Bin data
+    df["x_bin"] = pd.cut(df["x"], x_edges, labels=x_labels)
+
+    # Get aggregate statistics
+    df_agg = df.groupby("x_bin").agg(
+        {"y": ["count", "std", "min", "max", "mean"]}
+    )
+    # Flatten column names
+    df_agg.columns = ["_".join(c) for c in df_agg.columns]
+
+    # Reset the index
+    df_agg = df_agg.reset_index()
+
+    # Add the confidence interval of the mean to df_agg
+    df_agg["y_confidence"] = 1.96 * df_agg["y_std"] / np.sqrt(df_agg["y_count"])
+
+    # Plot the mean values
+    ax.plot(df_agg.x_bin, df_agg.y_mean, color=color, label=label)
+
+    # Plot the confidence interval
+    if show_confidence:
+        ax.fill_between(
+            df_agg.x_bin,
+            df_agg.y_mean - df_agg.y_confidence,
+            df_agg.y_mean + df_agg.y_confidence,
+            color=color,
+            alpha=0.2,
+        )
+
+        # Plot a dasshed line at confidence interval
+        ax.plot(
+            df_agg.x_bin,
+            df_agg.y_mean - df_agg.y_confidence,
+            color=color,
+            alpha=0.2,
+            ls="--",
+        )
+        ax.plot(
+            df_agg.x_bin,
+            df_agg.y_mean + df_agg.y_confidence,
+            color=color,
+            alpha=0.2,
+            ls="--",
+        )
+
+    # Plot the scatter points
+    if show_scatter:
+        ax.scatter(df.x, df.y, color=color, s=10, alpha=alpha_scatter)
+
+    # Plot the bin points, scaled by the counts
+    if show_bin_points:
+        ax.scatter(
+            df_agg.x_bin,
+            df_agg.y_mean,
+            color=color,
+            s=df_agg.y_count / df_agg.y_count.max() * 20,
+            alpha=0.5,
+            marker='s'
+        )
     
+# Small little demo of data plot, can delete
+if __name__ == "__main__":
 
+    # Declare some test data
+    x = np.random.uniform(0, 1, 1000)
+    y = 2 * x + 1 + np.random.normal(0, 0.1, 1000)
 
+    data_plot(x,y, show_scatter=True)
 
-    
+    plt.show()

--- a/flasc/visualization.py
+++ b/flasc/visualization.py
@@ -761,6 +761,8 @@ def data_plot(
             alpha=0.5,
             marker='s'
         )
+
+    return ax
     
 # Small little demo of data plot, can delete
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
Yes, maybe we can delete demo code after you approve and before merging

**Feature or improvement description**
data_plot was a function I'd found useful in the past for having an on hand way to represent noisy SCADA data (typical example might be achieved offset).  It exists in a pretty out-dated version in FLORIS, so I've added this updated version to FLASC, and will submit another pull request to FLORIS to remove the outdate code

**Impacted areas of the software**
visualization.py
