### PR TITLE
Add conversion from char to rgb

### DIFF
--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -110,6 +110,9 @@ def plot(
         # If nothing specified, use the default tableau colors from matplotlib.pyplot
         colors = [mcolors.to_rgb(clr) for clr in mcolors.TABLEAU_COLORS.keys()]
 
+    # In case colors is specified by a character, convert to RGB
+    colors = [mcolors.to_rgb(clr) for clr in colors]
+
 
     N = len(energy_ratios)
     if axarr is None:


### PR DESCRIPTION
Ready to be merged

**Feature or improvement description**
Had a small issue after the polar plotting pull request, a case I was running specified color to energy ratio plots via simple characters like 'k' or 'r', adding the .to_rgb command I think is harmless if already rgb, but converts to a tuple if supplied a character, and this avoids an error when this line in energy_ratio_visualization.py is run:

```
bar_color = colors[ii] + alpha_array[wsii] * (1.0 - np.array(colors[ii]))
```
Since you can't subtract a string from a float

