### PR TITLE
Feature: merge FlorisInterface objects

### DIFF
--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -62,9 +62,9 @@ def merge_floris_objects(fi_list, reference_wind_height=None):
         reference_wind_heights.append(fi.floris.flow_field.reference_wind_height)
 
     # Derive reference wind height, if unspecified by the user
-    if reference_wind_heights is None:
+    if reference_wind_height is None:
         reference_wind_height = np.mean(reference_wind_heights)
-        if np.any(np.abs(np.array(reference_wind_heights) - reference_wind_height)) > 1.0e-3:
+        if np.any(np.abs(np.array(reference_wind_heights) - reference_wind_height) > 1.0e-3):
             raise UserWarning("Cannot automatically derive a fitting reference_wind_height since they substantially differ between FlorisInterface objects. Please specify 'reference_wind_height' manually.")
 
     # Construct the merged FLORIS model based on the first entry in fi_list

--- a/tests/floris_tools_test.py
+++ b/tests/floris_tools_test.py
@@ -5,6 +5,7 @@ import pandas as pd
 import unittest
 from flasc.floris_tools import (
     calc_floris_approx_table,
+    merge_floris_objects,
     interpolate_floris_from_df_approx,
     get_dependent_turbines_by_wd
 )
@@ -22,6 +23,27 @@ def load_floris():
 
 
 class TestFlorisTools(unittest.TestCase):
+    def test_floris_merge(self):
+        fi_1 = load_floris()
+        fi_2 = fi_1.copy()
+        fi_2.reinitialize(layout_x=[-500.0, -500.0], layout_y=[0.0, 500.0])
+
+        # Check if layouts are merged appropriately
+        fi_merged = merge_floris_objects([fi_1, fi_2])
+        self.assertTrue(np.all(fi_merged.layout_x == np.hstack([fi_1.layout_x, fi_2.layout_x])))
+        self.assertTrue(np.all(fi_merged.layout_y == np.hstack([fi_1.layout_y, fi_2.layout_y])))
+# 
+        # Check if layouts are merged appropriately
+        fi_merged = merge_floris_objects([fi_1, fi_2], reference_wind_height=200.0)
+        self.assertTrue(fi_merged.floris.flow_field.reference_wind_height == 200.0)
+
+        # Also test that we raise a UserWarning if we have two different reference wind heights and
+        # don't specify a reference_wind_height for the merged object
+        with self.assertRaises(UserWarning):
+            fi_1.reinitialize(reference_wind_height=90.0)
+            fi_2.reinitialize(reference_wind_height=91.0)
+            fi_merged = merge_floris_objects([fi_1, fi_2])
+
     def test_floris_approx_table(self):
         # Load FLORIS object
         fi = load_floris()


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This feature adds a function to merge multiple FlorisInterface objects into a single object.

**Related issue, if one exists**
N/A.

**Impacted areas of the software**
`floris_tools`

**Additional supporting information**
This is a simple function that merges multiple FlorisInterface objects over their turbines. It does not merge wake properties or solver settings. This is helpful when wind farms are split over multiple sections with different turbine definitions, and when modeling neighboring wind farms.

**Test results, if applicable**
See the unit tests.

<!-- Release checklist:
- Update the version in
    - [ ] docs/source/conf.py
    - [ ] flasc/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLASC repository
-->