### PR TITLE
Update floris requirements to 3.4

### DIFF
--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -54,7 +54,7 @@ def merge_floris_objects(fi_list, reference_wind_height=None):
 
         fi_turbine_type = fi.floris.farm.turbine_type
         if len(fi_turbine_type) == 1:
-            fi_turbine_type = [fi_turbine_type] * len(fi.layout_x)
+            fi_turbine_type = fi_turbine_type * len(fi.layout_x)
         elif not len(fi_turbine_type) == len(fi.layout_x):
             raise UserWarning("Incompatible format of turbine_type in FlorisInterface.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-floris>=3.1
+floris>=3.4
 feather-format
 matplotlib>=3.6.3
 numpy

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ AUTHOR = "NREL National Wind Technology Center"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'floris>=3.1',
+    'floris>=3.4',
     'feather-format',
     'matplotlib>=3.6.3',
     'numpy',


### PR DESCRIPTION
Small pull request to raise the requirement of FLORIS up to 3.4.  I had thought this would require updating the example input yamls but with the exception of smarteole examples, these are anyway using the turbine_library input so don't need an update seperately