### PR TITLE
Feature: Add PyPI integration

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,30 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    if: github.repository_owner == 'NREL'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==========
+=============================================
 FLORIS-based Analysis for SCADA data (FLASC)
-==========
+=============================================
 
 **Further documentation is available at http://flasc.readthedocs.io/.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,161 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[coverage.run]
+# Coverage.py configuration file
+# https://coverage.readthedocs.io/en/latest/config.html
+branch = true
+source = "flasc/*"
+omit = [
+    "setup.py",
+    "tests/*"
+]
+
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+filterwarnings = [
+    "ignore::DeprecationWarning:pandas.*:"
+]
+
+
+
+## Pyflakes (F)
+## pycodestyle (E, W)
+# mccabe (C90)
+# isort (I)     # Use isort directly until more isort features are included in ruff
+# pep8-naming (N)
+# pydocstyle (D)
+# pyupgrade (UP)
+# flake8-2020 (YTT)
+# flake8-annotations (ANN)
+# flake8-bandit (S)
+# flake8-blind-except (BLE)
+# flake8-boolean-trap (FBT)
+# flake8-bugbear (B)
+# flake8-builtins (A)
+# flake8-commas (COM)
+# flake8-comprehensions (C4)
+# flake8-datetimez (DTZ)
+# flake8-debugger (T10)
+# flake8-errmsg (EM)
+# flake8-executable (EXE)
+# flake8-implicit-str-concat (ISC)
+# flake8-import-conventions (ICN)
+# flake8-logging-format (G)
+# flake8-no-pep420 (INP)
+# flake8-pie (PIE)
+# flake8-print (T20)
+# flake8-pytest-style (PT)
+# flake8-quotes (Q)
+# flake8-return (RET)
+# flake8-simplify (SIM)
+# flake8-tidy-imports (TID)
+# flake8-type-checking (TCH)
+# flake8-unused-arguments (ARG)
+# flake8-use-pathlib (PTH)
+# eradicate (ERA)
+# pandas-vet (PD)
+# pygrep-hooks (PGH)
+# Pylint (PL)
+# - Convention (PLC)
+# - Error (PLE)
+# - Refactor (PLR)
+# - Warning (PLW)
+# tryceratops (TRY)
+# flake8-raise (RSE)
+# flake8-self (SLF)
+# Ruff-specific rules (RUF)
+
+[tool.ruff]
+src = ["flasc", "tests"]
+line-length = 100
+target-version = "py310"
+
+# See https://github.com/charliermarsh/ruff#supported-rules
+# for rules included and matching to prefix.
+select = ["F", "E", "W", "C4", ] #"T20", "I"
+# I - isort is not fully implemented in ruff so there is not parity. Consider disabling I.
+
+# F401 unused-import: Ignore until all used isort flags are adopted in ruff
+ignore = ["F401"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+# fixable = ["A", "B", "C", "D", "E", "F"]
+fixable = ["F", "E", "W", "C4"] #"T20", "I"
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    "flasc/version.py",
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.per-file-ignores]
+# F841 unused-variable: ignore since this file uses numexpr and many variables look unused
+# ...
+
+# I001 unsorted-imports: ignore because the import order is meaningful to navigate
+# import dependencies
+# ...
+
+[tool.ruff.isort]
+combine-as-imports = true
+known-first-party = ["flasc"]
+order-by-type = false
+# lines-after-imports = 2
+
+# [tool.ruff.mccabe]
+# # Unlike Flake8, default to a complexity level of 10.
+# max-complexity = 10
+
+
+[tool.isort]
+sections = [
+    "FUTURE",
+    "STDLIB",
+    "THIRDPARTY",
+    "FIRSTPARTY",
+    "LOCALFOLDER"
+]
+known_first_party = [
+    "flasc"
+]
+multi_line_output = 3
+combine_as_imports = true
+force_grid_wrap = 3
+include_trailing_comma = true
+use_parentheses = true
+lines_after_imports = 2
+line_length = 100
+order_by_type = false
+split_on_trailing_comma = true
+
+# length_sort = true
+# case_sensitive: False
+# force_sort_within_sections: True
+# reverse_relative: True
+# sort_relative_in_force_sorted_sections: True

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     zip_safe=False,
     keywords='flasc',
     classifiers=[
-        'Development Status :: Release',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Adds PyPI integration so that FLASC becomes pip installable without having to clone the repository from GitHub.

**Related issue, if one exists**
Issue #49.

**Impacted areas of the software**
Code deployment.

**Additional supporting information**
I have followed the style of FLORIS in the `pyproject.toml` and `python-publish.yml` files.

**Test results, if applicable**
See my test deployment on the PyPI testing environment, https://test.pypi.org/project/flasc/1.4/. I bumped this to version 1.4 because I made a mistake when uploading 1.3, and you cannot upload the code for the same version number more than once.

**Steps remaining**
- [ ] Merge this branch
- [ ] Create PyPI API token: https://pypi.org/manage/account/#api-tokens and add it to your `~/.pypirc` file.
- [ ] Publish v1.3 on PyPI using code below

```
# Building the code
python3 -m pip install --upgrade build
python3 -m build

# Uploading the packaged code
python3 -m pip install --upgrade twine
python3 -m twine upload --repository pypi dist/*  # Upload distributions to PyPI
```


<!-- Release checklist:
- Update the version in
    - [ ] docs/source/conf.py
    - [ ] flasc/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLASC repository
-->