### PR TITLE
replace append with concat

### DIFF
--- a/flasc/energy_ratio/energy_ratio_visualization.py
+++ b/flasc/energy_ratio/energy_ratio_visualization.py
@@ -141,13 +141,14 @@ def plot(
         dwd = np.min(x[1::] - x[0:-1])
         jumps = np.where(np.diff(x) > dwd * 1.50)[0]
         if len(jumps) > 0:
-            df = df.append(
-                pd.DataFrame(
-                    {
-                        "wd_bin": x[jumps] + dwd / 2.0,
-                        "N_bin": [0] * len(jumps),
-                    }
-                )
+            df = pd.concat([df,
+                    pd.DataFrame(
+                        {
+                            "wd_bin": x[jumps] + dwd / 2.0,
+                            "N_bin": [0] * len(jumps),
+                        }
+                    )
+                ]
             )
             df = df.iloc[np.argsort(df["wd_bin"])].reset_index(drop=True)
             x = np.array(df["wd_bin"], dtype=float)


### PR DESCRIPTION
Elizabeth found a bug in FLASC that if you install now, pandas 2.0 is installed, and it no longer supports the append statement.  This causes an error in the example: flasc/examples_smarteole/05_baseline_energy_ratio_analysis.ipynb

This bugfix resolves the issue by replacing the deprecated append, with concat
