### PR TITLE
Feature: Add floris turbine power curve option in mean ws-power-curve plot

### DIFF
--- a/flasc/turbine_analysis/ws_pow_filtering.py
+++ b/flasc/turbine_analysis/ws_pow_filtering.py
@@ -673,7 +673,7 @@ class ws_pw_curve_filtering:
         """
         return self.pw_curve_df
 
-    def plot_farm_mean_power_curve(self):
+    def plot_farm_mean_power_curve(self, fi=None):
         """Plot all turbines' power curves in a single figure. Also estimate
         and plot a mean turbine power curve.
         """
@@ -696,9 +696,20 @@ class ws_pw_curve_filtering:
             alpha=0.30,
         )
         ax.plot(x, pow_mean_array, color="tab:red", label="Mean curve")
+
+        if fi is not None:
+            fi_turb = fi.floris.farm.turbine_definitions[ti]
+            Ad = 0.25 * np.pi * fi_turb["rotor_diameter"] ** 2.0
+            ws_array = np.array(fi_turb["power_thrust_table"]["wind_speed"])
+            cp_array = np.array(fi_turb["power_thrust_table"]["power"])
+            rho = fi.floris.flow_field.air_density
+            pow_array = (
+                0.5 * rho * ws_array ** 3.0 * Ad * cp_array * 1.0e-3
+            )
+            ax.plot(ws_array, pow_array, "--", label="FLORIS curve")
+
         ax.legend()
         ax.set_title("Mean of all turbine power curves with UQ")
-
         return fig, ax
 
     def plot_filters_custom_scatter(self, ti, x_col, y_col, ax=None):

--- a/flasc/turbine_analysis/ws_pow_filtering.py
+++ b/flasc/turbine_analysis/ws_pow_filtering.py
@@ -676,7 +676,13 @@ class ws_pw_curve_filtering:
     def plot_farm_mean_power_curve(self, fi=None):
         """Plot all turbines' power curves in a single figure. Also estimate
         and plot a mean turbine power curve.
+
+        Args:
+            fi (FlorisInterface): The FlorisInterface object for the farm. If
+              specified by the user, then the farm-average turbine power curve
+              from FLORIS will be plotted on top of the SCADA-based power curves.
         """
+
         fig, ax = plt.subplots()
         x = np.array(self.pw_curve_df["ws"], dtype=float)
         for ti in range(self.n_turbines):


### PR DESCRIPTION
This PR **is ready** to be merged.

**Feature or improvement description**
Adds the option to plot the FLORIS power curve in the mean power curve plots.

**Related issue, if one exists**
N/A

**Impacted areas of the software**
`ws_pow_curve_filtering`

**Additional supporting information**
This makes it easy to compare the farm-averaged SCADA-based turbine power curve with the one predicted by FLORIS.

**Test results, if applicable**
N/A

<!-- Release checklist:
- Update the version in
    - [ ] docs/source/conf.py
    - [ ] flasc/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLASC repository
-->