### PR TITLE
Bug fix: properly assign reference turbine location in calculating closest subset of turbines

### DIFF
--- a/flasc/dataframe_operations/dataframe_manipulations.py
+++ b/flasc/dataframe_operations/dataframe_manipulations.py
@@ -115,7 +115,7 @@ def _set_col_by_n_closest_upstream_turbines(col_out, col_prefix, df, N,
         # Calculate distances and get closest N upstream turbines
         upstr_turbs = [ti for ti in upstr_turbs if ti not in exclude_turbs]
         x0 = x_turbs[turb_no]
-        y0 = x_turbs[turb_no]
+        y0 = y_turbs[turb_no]
         x_upstr = np.array(x_turbs, dtype=float)[upstr_turbs]
         y_upstr = np.array(y_turbs, dtype=float)[upstr_turbs]
         ds = np.sqrt((x_upstr - x0) ** 2.0 + (y_upstr - y0) ** 2.0)


### PR DESCRIPTION
This PR **is ready** to be merged.
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This fixes a bug in which the relative distance between turbines is not properly calculated when assigning reference values by the closest `N` number of turbines.

**Related issue, if one exists**
N/A

**Impacted areas of the software**
Dataframe manipulations.

**Additional supporting information**
N/A

**Test results, if applicable**
N/A

<!-- Release checklist:
- Update the version in
    - [ ] docs/source/conf.py
    - [ ] flasc/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLASC repository
-->