### PR TITLE
Change nan behavior

### DIFF
--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -84,6 +84,8 @@ def _compute_energy_ratio_single(df_,
     # Filter df_ to remove null values
     null_filter = filter_all_nulls if remove_all_nulls else filter_any_nulls
     df_ = null_filter(df_, ref_cols, test_cols, ws_cols, wd_cols)
+    if len(df_) == 0:
+        raise RuntimeError("After removing nulls, no data remains for computation.")
 
     # If wd_bin_overlap_radius is not zero, add reflected rows
     if wd_bin_overlap_radius > 0.:

--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -68,8 +68,16 @@ def _compute_energy_ratio_single(df_,
     num_df = len(df_names)
 
     # Filter df_ that all the columns are not null
-    print(ref_cols + test_cols + ws_cols + wd_cols)
-    df_ = df_.filter(pl.all_horizontal(pl.col(ref_cols + test_cols + ws_cols + wd_cols).is_not_null()))
+
+    # Former behavior which requires all
+    # df_ = df_.filter(pl.all_horizontal(pl.col(ref_cols + test_cols + ws_cols + wd_cols).is_not_null()))
+
+    # New any behavior
+    df_ = (df_.filter(pl.any_horizontal(pl.col(ref_cols).is_not_null()))
+            .filter(pl.any_horizontal(pl.col(test_cols).is_not_null()))
+            .filter(pl.any_horizontal(pl.col(ws_cols).is_not_null()))
+            .filter(pl.any_horizontal(pl.col(wd_cols).is_not_null()))
+    )
 
     # If wd_bin_overlap_radius is not zero, add reflected rows
     if wd_bin_overlap_radius > 0.:

--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -19,6 +19,7 @@ from flasc.energy_ratio.energy_ratio_utilities import (
     add_power_ref,
     add_power_test,
     add_reflected_rows,
+    check_compute_energy_ratio_inputs,
     filter_all_nulls,
     filter_any_nulls
 )
@@ -302,55 +303,30 @@ def compute_energy_ratio(er_in: EnergyRatioInput,
     # Get the polars dataframe from within the er_in
     df_ = er_in.get_df()
 
-    # Check that the inputs are valid
-    # If use_predefined_ref is True, df_ must have a column named 'pow_ref'
-    if use_predefined_ref:
-        if 'pow_ref' not in df_.columns:
-            raise ValueError('df_ must have a column named pow_ref when use_predefined_ref is True')
-        # If ref_turbines supplied, warn user that it will be ignored
-        if ref_turbines is not None:
-            warnings.warn('ref_turbines will be ignored when use_predefined_ref is True')
-    else:
-        # ref_turbine must be supplied
-        if ref_turbines is None:
-            raise ValueError('ref_turbines must be supplied when use_predefined_ref is False')
-        
-    # If use_predefined_ws is True, df_ must have a column named 'ws'
-    if use_predefined_ws:
-        if 'ws' not in df_.columns:
-            raise ValueError('df_ must have a column named ws when use_predefined_ws is True')
-        # If ws_turbines supplied, warn user that it will be ignored
-        if ws_turbines is not None:
-            warnings.warn('ws_turbines will be ignored when use_predefined_ws is True')
-    else:
-        # ws_turbine must be supplied
-        if ws_turbines is None:
-            raise ValueError('ws_turbines must be supplied when use_predefined_ws is False')
-
-    # If use_predefined_wd is True, df_ must have a column named 'wd'
-    if use_predefined_wd:
-        if 'wd' not in df_.columns:
-            raise ValueError('df_ must have a column named wd when use_predefined_wd is True')
-        # If wd_turbines supplied, warn user that it will be ignored
-        if wd_turbines is not None:
-            warnings.warn('wd_turbines will be ignored when use_predefined_wd is True')
-    else:
-        # wd_turbine must be supplied
-        if wd_turbines is None:
-            raise ValueError('wd_turbines must be supplied when use_predefined_wd is False')
-        
-
-    # Confirm that test_turbines is a list of ints or a numpy array of ints
-    if not isinstance(test_turbines, list) and not isinstance(test_turbines, np.ndarray):
-        raise ValueError('test_turbines must be a list or numpy array of ints')
-
-    # Confirm that test_turbines is not empty  
-    if len(test_turbines) == 0:
-        raise ValueError('test_turbines cannot be empty')
-    
-    # Confirm that wd_bin_overlap_radius is less than or equal to wd_step/2
-    if wd_bin_overlap_radius > wd_step/2:
-        raise ValueError('wd_bin_overlap_radius must be less than or equal to wd_step/2')
+    # Check that inputs are valid
+    check_compute_energy_ratio_inputs(
+        df_,
+        ref_turbines,
+        test_turbines,
+        wd_turbines,
+        ws_turbines,
+        use_predefined_ref,
+        use_predefined_wd,
+        use_predefined_ws,
+        wd_step,
+        wd_min,
+        wd_max,
+        ws_step,
+        ws_min,
+        ws_max,
+        bin_cols_in,
+        wd_bin_overlap_radius,
+        uplift_pairs,
+        uplift_names,
+        N,
+        percentiles,
+        remove_all_nulls
+    )
     
      # Set up the column names for the reference and test power
     if not use_predefined_ref:

--- a/flasc/energy_ratio/energy_ratio_input.py
+++ b/flasc/energy_ratio/energy_ratio_input.py
@@ -4,7 +4,6 @@ import polars as pl
 
 from typing import Optional, Dict, List, Any, Tuple, Union
 
-from flasc.energy_ratio.energy_ratio_utilities import add_ws_bin, add_wd_bin
 from flasc.dataframe_operations.dataframe_manipulations import df_reduce_precision
 
 

--- a/flasc/energy_ratio/energy_ratio_output.py
+++ b/flasc/energy_ratio/energy_ratio_output.py
@@ -84,7 +84,15 @@ class EnergyRatioOutput:
         df_ = self.er_in.get_df()
 
         # Filter df_ that all the columns are not null
-        df_ = df_.filter(pl.all_horizontal(pl.col(self.ref_cols + self.test_cols + self.ws_cols + self.wd_cols).is_not_null()))
+        # Former behavior which requires all
+        #df_ = df_.filter(pl.all_horizontal(pl.col(self.ref_cols + self.test_cols + self.ws_cols + self.wd_cols).is_not_null()))
+
+        # New any behavior
+        df_ = (df_.filter(pl.any_horizontal(pl.col(self.ref_cols).is_not_null()))
+                .filter(pl.any_horizontal(pl.col(self.test_cols).is_not_null()))
+                .filter(pl.any_horizontal(pl.col(self.ws_cols).is_not_null()))
+                .filter(pl.any_horizontal(pl.col(self.wd_cols).is_not_null()))
+        )
 
         # Assign the wd/ws bins
         df_ = add_ws_bin(df_, self.ws_cols, self.ws_step, self.ws_min, self.ws_max)

--- a/flasc/energy_ratio/energy_ratio_utilities.py
+++ b/flasc/energy_ratio/energy_ratio_utilities.py
@@ -1,3 +1,4 @@
+import warnings
 import polars as pl
 import numpy as np
 
@@ -367,3 +368,83 @@ def filter_any_nulls(
             .filter(pl.any_horizontal(pl.col(ws_cols).is_not_null()))
             .filter(pl.any_horizontal(pl.col(wd_cols).is_not_null()))
     )
+
+def check_compute_energy_ratio_inputs(
+    df_,
+    ref_turbines,
+    test_turbines,
+    wd_turbines,
+    ws_turbines,
+    use_predefined_ref,
+    use_predefined_wd,
+    use_predefined_ws,
+    wd_step,
+    wd_min,
+    wd_max,
+    ws_step,
+    ws_min,
+    ws_max,
+    bin_cols_in,
+    wd_bin_overlap_radius,
+    uplift_pairs,
+    uplift_names,
+    N,
+    percentiles,
+    remove_all_nulls
+):
+    """
+    Check inputs to compute_energy_ratio. Inputs reflect inputs to compute_energy_ratio,
+    with exception of df_, which is passed directly instead of er_in.
+    """
+
+    # Check that the inputs are valid
+    # If use_predefined_ref is True, df_ must have a column named 'pow_ref'
+    if use_predefined_ref:
+        if 'pow_ref' not in df_.columns:
+            raise ValueError('df_ must have a column named pow_ref when use_predefined_ref is True')
+        # If ref_turbines supplied, warn user that it will be ignored
+        if ref_turbines is not None:
+            warnings.warn('ref_turbines will be ignored when use_predefined_ref is True')
+    else:
+        # ref_turbine must be supplied
+        if ref_turbines is None:
+            raise ValueError('ref_turbines must be supplied when use_predefined_ref is False')
+        
+    # If use_predefined_ws is True, df_ must have a column named 'ws'
+    if use_predefined_ws:
+        if 'ws' not in df_.columns:
+            raise ValueError('df_ must have a column named ws when use_predefined_ws is True')
+        # If ws_turbines supplied, warn user that it will be ignored
+        if ws_turbines is not None:
+            warnings.warn('ws_turbines will be ignored when use_predefined_ws is True')
+    else:
+        # ws_turbine must be supplied
+        if ws_turbines is None:
+            raise ValueError('ws_turbines must be supplied when use_predefined_ws is False')
+
+    # If use_predefined_wd is True, df_ must have a column named 'wd'
+    if use_predefined_wd:
+        if 'wd' not in df_.columns:
+            raise ValueError('df_ must have a column named wd when use_predefined_wd is True')
+        # If wd_turbines supplied, warn user that it will be ignored
+        if wd_turbines is not None:
+            warnings.warn('wd_turbines will be ignored when use_predefined_wd is True')
+    else:
+        # wd_turbine must be supplied
+        if wd_turbines is None:
+            raise ValueError('wd_turbines must be supplied when use_predefined_wd is False')
+        
+
+    # Confirm that test_turbines is a list of ints or a numpy array of ints
+    if not isinstance(test_turbines, list) and not isinstance(test_turbines, np.ndarray):
+        raise ValueError('test_turbines must be a list or numpy array of ints')
+
+    # Confirm that test_turbines is not empty  
+    if len(test_turbines) == 0:
+        raise ValueError('test_turbines cannot be empty')
+    
+    # Confirm that wd_bin_overlap_radius is less than or equal to wd_step/2
+    if wd_bin_overlap_radius > wd_step/2:
+        raise ValueError('wd_bin_overlap_radius must be less than or equal to wd_step/2')
+
+    return None

--- a/flasc/energy_ratio/energy_ratio_utilities.py
+++ b/flasc/energy_ratio/energy_ratio_utilities.py
@@ -81,7 +81,8 @@ def add_ws(df_: pl.DataFrame,
             ws = pl.concat_list(ws_cols).list.mean() # Initially ws_bin is just the mean
         )
         .filter(
-            pl.all_horizontal(pl.col(ws_cols).is_not_null()) # Select for all bin cols present
+            # pl.all_horizontal(pl.col(ws_cols).is_not_null()) # Select for all bin cols present
+            pl.any_horizontal(pl.col(ws_cols).is_not_null()) # Select for all bin cols present
         ) 
 
         .filter(
@@ -162,7 +163,8 @@ def add_wd(df_:pl.DataFrame,
     df_with_mean_wd =  (
         # df_.select(pl.exclude('wd_bin')) # In case wd_bin already exists
         df_.filter(
-            pl.all_horizontal(pl.col(wd_cols).is_not_null()) # Select for all bin cols present
+            # pl.all_horizontal(pl.col(wd_cols).is_not_null()) # Select for all bin cols present
+            pl.any_horizontal(pl.col(wd_cols).is_not_null()) # Select for all bin cols present
         ) 
         # Add the cosine columns
         .with_columns(

--- a/tests/energy_ratio_test.py
+++ b/tests/energy_ratio_test.py
@@ -192,3 +192,39 @@ class TestEnergyRatio(unittest.TestCase):
         edges = np.array([358, 360])
         df_reflected = add_reflected_rows(df, edges,0.25)
         assert_frame_equal(df_result_expected, df_reflected)
+
+    def test_null_behavior(self):
+
+        # Test that in the default, an energy ratio is returned so long as any value is not null
+        df = pd.DataFrame({'wd_000': [268., 270., 272.,272.,],
+                           'wd_001': [np.nan, 270., 272. ,272.],
+                           'ws': [8., 8., 8.,8.],
+                           'pow_000': [100., 100., 100., 100.],
+                           'pow_001': [100., np.nan, np.nan,np.nan],
+                           'pow_002': [100., 100., 200.,np.nan],
+        })
+
+        er_in = EnergyRatioInput([df],['baseline'],num_blocks=1)
+
+        er_out = erp.compute_energy_ratio(
+            er_in,
+            ref_turbines=[0,1],
+            test_turbines=[2],
+            wd_turbines = [0,1],
+            use_predefined_ws=True,
+            wd_min = 267.,
+            wd_step=2.0,
+            ws_step=1.0,
+            N=1,
+        )
+
+        print(er_out.df_result)
+
+
+        self.assertAlmostEqual(er_out.df_result['baseline'].iloc[0], 1., places=4)
+        self.assertAlmostEqual(er_out.df_result['baseline'].iloc[1], 1., places=4)
+        self.assertAlmostEqual(er_out.df_result['baseline'].iloc[2], 2., places=4)
+
+        self.assertEqual(er_out.df_result['count_baseline'].iloc[0], 1)
+        self.assertEqual(er_out.df_result['count_baseline'].iloc[1], 1)
+        self.assertEqual(er_out.df_result['count_baseline'].iloc[2], 1)


### PR DESCRIPTION
Ready to be merged (maybe can delete some commented out lines)

**Feature or improvement description**
This pull request address Issue #119 , where we inadvertently changed nan filtering from an "Any" to an "All" in the conversion of energy ratio from pandas to polars.  This pull requests fixes the convention back, and adds a test to confirm the expected behavior (and check going forward)

**Related issue, if one exists**
#119

**Impacted areas of the software**
energy_ratio.py
energy_ratio_output.py
energy_ratio_utiltities.py
energy_ratio_test.py
