### PR TITLE
Feature/add options on count

### DIFF
--- a/examples_artificial_data/03_energy_ratio/05_wake_steering_example.py
+++ b/examples_artificial_data/03_energy_ratio/05_wake_steering_example.py
@@ -10,20 +10,16 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-import numpy as np
+
 import matplotlib.pyplot as plt
-import os
+import numpy as np
 import pandas as pd
 import seaborn as sns
 
-from floris import tools as wfct
-from floris.utilities import wrap_360
-
 from flasc.energy_ratio import energy_ratio as er
 from flasc.energy_ratio.energy_ratio_input import EnergyRatioInput
-# from flasc import floris_tools as fsatools
-from flasc.visualization import plot_layout_with_waking_directions, plot_binned_mean_and_ci
 from flasc.utilities_examples import load_floris_artificial as load_floris
+from flasc.visualization import plot_binned_mean_and_ci, plot_layout_with_waking_directions
 
 
 if __name__ == "__main__":
@@ -101,7 +97,7 @@ if __name__ == "__main__":
 
     # Create alternative versions of each of the above dataframes where the wd/ws are perturbed by noise
     df_baseline_noisy = pd.DataFrame({
-        'wd':wd_array + np.random.randn(len(wd_array))*5,
+        'wd':wd_array + np.random.randn(len(wd_array))*2,
         'ws':ws_array + np.random.randn(len(ws_array)),
         'pow_ref':power_baseline_ref,
         'pow_000':power_baseline_ref, 
@@ -110,7 +106,7 @@ if __name__ == "__main__":
     })
 
     df_wakesteering_noisy = pd.DataFrame({
-        'wd':wd_array + np.random.randn(len(wd_array))*5,
+        'wd':wd_array + np.random.randn(len(wd_array))*2,
         'ws':ws_array + np.random.randn(len(ws_array)),
         'pow_ref':power_wakesteering_ref,
         'pow_000':power_wakesteering_ref, 
@@ -129,20 +125,12 @@ if __name__ == "__main__":
 
     # Make a color palette that visually links the nominal and noisy data sets together
     color_palette = sns.color_palette("Paired",4)[::-1]
-    # color_palette = ['r','g','b','k']
 
-    # Initialize the energy ratio suite object and add each dataframe
-    # separately. 
-
+    # Initialize the energy ratio input object
     er_in = EnergyRatioInput(
         [df_baseline, df_wakesteering, df_baseline_noisy, df_wakesteering_noisy], 
         ["Baseline", "WakeSteering", "Baseline (Noisy)", "WakeSteering (Noisy)"]
     )
-
-    # fsc.add_df(df_baseline, 'Baseline', color_palette[0])
-    # fsc.add_df(df_wakesteering, 'WakeSteering', color_palette[1])
-    # fsc.add_df(df_baseline_noisy, 'Baseline (Noisy)', color_palette[2])
-    # fsc.add_df(df_wakesteering_noisy, 'WakeSteering (Noisy)', color_palette[3])
 
     # Calculate and plot the energy ratio for the downstream turbine [2]
     # With respect to reference turbine [0]
@@ -159,16 +147,10 @@ if __name__ == "__main__":
         percentiles=[5., 95.],
         uplift_pairs=[("Baseline", "WakeSteering"), 
                       ("Baseline (Noisy)", "WakeSteering (Noisy)")],
-        uplift_names=["Clean", "Noisy"]
+        uplift_names=["Clean", "Noisy"],
+        weight_by='min'
     )
-    # fsc.get_energy_ratios(
-    #     test_turbines=[2],
-    #     wd_step=2.0,
-    #     ws_step=1.0,
-    #     N=10,
-    #     percentiles=[5., 95.],
-    #     verbose=False
-    # )
+
     er_out.plot_energy_ratios(
         color_dict={"Baseline":"blue", 
                     "WakeSteering":"green", 

--- a/flasc/energy_ratio/energy_ratio.py
+++ b/flasc/energy_ratio/energy_ratio.py
@@ -194,8 +194,7 @@ def _compute_energy_ratio_bootstrap(er_in,
         ws_max (float): The maximum wind speed to use.
         bin_cols_in (list[str]): A list of column names to use for the wind speed and wind direction bins.
         weight_by (str): How to weight the energy ratio, options are 'min', or 'sum'.  'min' means
-            the minimum count across the dataframes is used to weight the energy ratio.  'mean' means the mean
-            count across the dataframes is used to weight the energy ratio.  'sum' means the sum of the counts
+            the minimum count across the dataframes is used to weight the energy ratio. 'sum' means the sum of the counts
             across the dataframes is used to weight the energy ratio.
         wd_bin_overlap_radius (float): The distance in degrees one wd bin overlaps into the next, must be 
             less or equal to half the value of wd_step

--- a/flasc/energy_ratio/energy_ratio_output.py
+++ b/flasc/energy_ratio/energy_ratio_output.py
@@ -59,7 +59,7 @@ class EnergyRatioOutput:
             ws_min (float): The minimum wind speed value.
             ws_max (float): The maximum wind speed value.
             bin_cols_in (List[str]): TBD
-            weight_by (str): How to weight the energy ratio, options are 'min', , or 'sum'.  'min' means
+            weight_by (str): How to weight the energy ratio, options are 'min', or 'sum'.  'min' means
                 the minimum count across the dataframes is used to weight the energy ratio.   'sum' means the sum of the counts
                 across the dataframes is used to weight the energy ratio.
             wd_bin_overlap_radius (float): The radius of overlap between wind direction bins.

--- a/flasc/energy_ratio/energy_ratio_output.py
+++ b/flasc/energy_ratio/energy_ratio_output.py
@@ -37,6 +37,7 @@ class EnergyRatioOutput:
                  ws_min: float,
                  ws_max: float,
                  bin_cols_in: List[str],
+                 weight_by: str,
                  wd_bin_overlap_radius: float,
                  N: int,
                  remove_all_nulls: bool = False
@@ -58,6 +59,9 @@ class EnergyRatioOutput:
             ws_min (float): The minimum wind speed value.
             ws_max (float): The maximum wind speed value.
             bin_cols_in (List[str]): TBD
+            weight_by (str): How to weight the energy ratio, options are 'min', , or 'sum'.  'min' means
+                the minimum count across the dataframes is used to weight the energy ratio.   'sum' means the sum of the counts
+                across the dataframes is used to weight the energy ratio.
             wd_bin_overlap_radius (float): The radius of overlap between wind direction bins.
             N (int): The number of bootstrap iterations used in the energy ratio calculation.
             remove_all_nulls: (bool): Construct reference and test by strictly requiring all data to be 
@@ -80,6 +84,7 @@ class EnergyRatioOutput:
         self.ws_min = ws_min
         self.ws_max = ws_max
         self.bin_cols_in = bin_cols_in
+        self.weight_by = weight_by
         self.wd_bin_overlap_radius = wd_bin_overlap_radius
         self.N = N
         self.remove_all_nulls = remove_all_nulls
@@ -99,17 +104,18 @@ class EnergyRatioOutput:
 
         # Assign the wd/ws bins
         df_ = add_ws_bin(df_, self.ws_cols, self.ws_step, self.ws_min, self.ws_max,
-            remove_all_bins=self.remove_all_nulls)
+            remove_all_nulls=self.remove_all_nulls)
         df_ = add_wd_bin(df_, self.wd_cols, self.wd_step, self.wd_min, self.wd_max,
-            remove_all_bins=self.remove_all_nulls)
+            remove_all_nulls=self.remove_all_nulls)
 
         # Get the bin count by wd, ws and df_name
         df_group = df_.groupby(['wd_bin','ws_bin','df_name']).count()
 
         # Collect the minimum number of points per bin
         df_min = df_group.groupby(['wd_bin','ws_bin']).min()
+        df_sum = df_group.groupby(['wd_bin','ws_bin']).sum()
 
-        return df_.to_pandas(), df_group.to_pandas(), df_min.to_pandas()
+        return df_.to_pandas(), df_group.to_pandas(), df_min.to_pandas(), df_sum.to_pandas()
 
     def plot_energy_ratios(self,
         df_names_subset: Optional[List[str]] = None,
@@ -312,14 +318,20 @@ class EnergyRatioOutput:
             bar_width = bar_width * np.pi / 180.0
 
         # Plot the bin counts
-        _, df_freq, df_min = self._compute_df_freq()
+        _, df_freq, df_min, df_sum  = self._compute_df_freq()
         df_freq_sum_all_ws = df_freq.groupby(["wd_bin","df_name"]).sum().reset_index()
 
         for i, (df_name, label) in enumerate(zip(df_names_subset, labels)):
-            if _is_uplift: # Special case, use the minimum
-                df_sub = df_min
+            if _is_uplift: # Special case, use the minimum or the sum
+                if self.weight_by == 'min':
+                    df_sub = df_min
+                    ax.set_title('Minimum of Points per Bin')
+                else:
+                    df_sub = df_sum
+                    ax.set_title('Sum of Points per Bin')
             else:
                 df_sub = df_freq_sum_all_ws[df_freq_sum_all_ws["df_name"] == df_name]
+                ax.set_title('Number of Points per Bin')
             
             x = np.array(df_sub["wd_bin"], dtype=float)
             if polar_plot: # Convert to radians
@@ -328,7 +340,7 @@ class EnergyRatioOutput:
 
         ax.legend()
         ax.set_ylabel('Number of Points')
-        ax.set_title('Number of Points per Bin')
+        
         ax.grid(True)
 
         # Wind Speed Distribtution Plot ========================================
@@ -338,10 +350,15 @@ class EnergyRatioOutput:
 
         ax = axarr[2]        
 
-        sns.scatterplot(data=df_min, x='wd_bin', y='ws_bin', size='count',hue='count', ax=ax, legend=True, color='k')
+        if self.weight_by == 'min':
+            sns.scatterplot(data=df_min, x='wd_bin', y='ws_bin', size='count',hue='count', ax=ax, legend=True, color='k')
+            ax.set_title('Minimum Number of Points per Bin')
+        else:
+            sns.scatterplot(data=df_sum, x='wd_bin', y='ws_bin', size='count',hue='count', ax=ax, legend=True, color='k')
+            ax.set_title('Sum of Points per Bin')
         ax.set_xlabel('Wind Direction (deg)')
         ax.set_ylabel('Wind Speed (m/s)')
-        ax.set_title('Minimum Number of Points per Bin')
+        
         ax.grid(True)
 
         return axarr
@@ -472,8 +489,8 @@ class EnergyRatioOutput:
         if not show_wind_direction_distribution:
             return axarr
 
-        # Finish Wind Direction Distribution plot
-        ax = axarr[1]
-        ax.set_title("Minimum Number of Points per Bin")
+        # # Finish Wind Direction Distribution plot
+        # ax = axarr[1]
+        # ax.set_title("Minimum Number of Points per Bin")
 
         return axarr

--- a/flasc/energy_ratio/energy_ratio_utilities.py
+++ b/flasc/energy_ratio/energy_ratio_utilities.py
@@ -385,6 +385,7 @@ def check_compute_energy_ratio_inputs(
     ws_min,
     ws_max,
     bin_cols_in,
+    weight_by,
     wd_bin_overlap_radius,
     uplift_pairs,
     uplift_names,
@@ -446,5 +447,9 @@ def check_compute_energy_ratio_inputs(
     # Confirm that wd_bin_overlap_radius is less than or equal to wd_step/2
     if wd_bin_overlap_radius > wd_step/2:
         raise ValueError('wd_bin_overlap_radius must be less than or equal to wd_step/2')
+    
+    # Confirm the weight_by argument is valid
+    if weight_by not in ['min', 'sum']:
+        raise ValueError('weight_by must be one of "min", or "sum"')
 
     return None


### PR DESCRIPTION
Ready to be merged

**Feature or improvement description**
This pull request changes the current behavior that assumes, when weighting wind speed bins in the energy ratio across dataframes, that we should use the minimum count (thus up-weighting the wind-speed bins that have the most points in the lesser case), allow an option to weight by sum.  Minimum will stay the default but now an option to pass in 'sum' to a new weight_by variable.

The pull request includes a new test which shows and checks the functionality on a small problem

Finally, a small unrelated bug in energy_ratio_output (remove_all_bins used instead of remove_all_nulls is fixed) and the energy_ratio example for wake steering is cleaned up.


**Additional supporting information**
This is in support of functions to compute total uplift

**Test results, if applicable**
New test added test_alternative_weighting, all tests pass

