### PR TITLE
Feature/update reqs pin polars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ AUTHOR = "NREL National Wind Technology Center"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'bokeh~=3.1.1',
+    'bokeh~=3.1',
     'floris~=3.4',
     'feather-format~=0.0',
     'ipympl~=0.9',

--- a/setup.py
+++ b/setup.py
@@ -12,21 +12,20 @@ AUTHOR = "NREL National Wind Technology Center"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'bokeh>=3.1.1',
-    'floris>=3.4',
-    'feather-format',
-    'ipympl>=0.9.3',
-    'matplotlib>=3.6.3',
-    'numpy',
-    'pandas>=1.5',
-    'pyproj',
-    'pytest',
-    'SALib',
-    'scipy',
-    'sqlalchemy',
-    'streamlit',
-    'tkcalendar',
-    'seaborn',
+    'bokeh~=3.1.1',
+    'floris~=3.4',
+    'feather-format~=0.0',
+    'ipympl~=0.9',
+    'matplotlib~=3.6',
+    "numpy~=1.20",
+    "pandas~=2.0",
+    'pyproj~=3.0',
+    'SALib~=1.0',
+    "scipy~=1.1",
+    'sqlalchemy~=2.0',
+    'streamlit~=1.0',
+    'tkcalendar~=1.0',
+    'seaborn~=0.0',
     'polars==0.19.5'
 ]
 


### PR DESCRIPTION
Ready to be merged

**Feature or improvement description**
This pull request implements two small changes to the requirements:

- Changes dependent versioning to use latest compatible version (semantic versioning) [Issue #139]
- Reinforces that we're back-pinning polars until we agree on general [Issue #133 ]

Except for polars, requirements specified via ~=1.1, which is interpreted as >=1.1, ==1.*, which essentially means latest minor version which matches major version, and is >= minor version specified.  Can see:

https://packaging.python.org/en/latest/specifications/version-specifiers/#id4

**Related issue, if one exists**
Closes #139 
Issue #133 

**Impacted areas of the software**
setup.py

