### PR TITLE
Feature: Heterogeneity estimator class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ docs/build
 SMARTEOLE_WakeSteering_ReadMe.xlsx
 SMARTEOLE_WakeSteering_Map.pdf
 SMARTEOLE-WFC-open-dataset.zip
+examples_artificial_data/03_energy_ratio/heterogeneity_layouts.pdf

--- a/examples_artificial_data/03_energy_ratio/05_estimate_heterogeneity_from_energy_ratios.py
+++ b/examples_artificial_data/03_energy_ratio/05_estimate_heterogeneity_from_energy_ratios.py
@@ -1,16 +1,18 @@
 import os
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 from floris.utilities import wrap_360
 
-from flasc import floris_tools as ftools
 from flasc.dataframe_operations import dataframe_manipulations as dfm
+from flasc import floris_tools as ftools
 from flasc.energy_ratio import energy_ratio as er
 from flasc.energy_ratio.energy_ratio_input import EnergyRatioInput
-from flasc.utilities_examples import load_floris_artificial as load_floris
 from flasc.visualization import plot_floris_layout
+from flasc.utilities_examples import load_floris_artificial as load_floris
+
+from flasc.energy_ratio.energy_ratio_heterogeneity_mapper import heterogeneity_mapper
 
 
 def load_data():
@@ -32,112 +34,6 @@ def load_data():
     return df
 
 
-def get_energy_ratio(df, ti, aligned_wd):
-    # Calculate and plot energy ratios
-    # s = energy_ratio_suite.energy_ratio_suite(verbose=False)
-    er_in = EnergyRatioInput([df], ["Raw data (wind direction calibrated)"])
-    # s.add_df(df, 'Raw data (wind direction calibrated)')
-    return er.compute_energy_ratio(
-        er_in,
-        test_turbines=[ti],
-        use_predefined_ref=True,
-        use_predefined_wd=True,
-        use_predefined_ws=True,
-        wd_step=15.0,
-        wd_bin_overlap_radius=0.0,
-        wd_min=aligned_wd - 15.0 / 2,
-        wd_max=aligned_wd + 15.0 / 2,
-        ws_min=6.0,
-        ws_max=10.0,
-        N=10,
-        percentiles=[5.0, 95.0],
-    )
-
-
-def _process_single_wd(wd, wd_bin_width, turb_wd_measurement, df_upstream, df):
-    # In this function, we calculate the energy ratios of all upstream
-    # turbines for a single wind direction bin and single wind speed bin.
-    # The difference in energy ratios between different upstream turbines
-    # gives a strong indication of the heterogeneity in the inflow wind
-    # speeds for that mean inflow wind direction.
-    print("Processing wind direction = {:.1f} deg.".format(wd))
-    # wd_bins = [[wd - wd_bin_width / 2.0, wd + wd_bin_width / 2.0]]
-
-    # Determine which turbines are upstream
-    if wd > df_upstream.iloc[0]["wd_max"]:
-        turbine_array = df_upstream.loc[
-            (wd > df_upstream["wd_min"]) & (wd <= df_upstream["wd_max"]), "turbines"
-        ].values[0]
-
-    # deal with wd = 0 deg (or close to 0.0)
-    else:
-        turbine_array = df_upstream.loc[
-            (wrap_360(wd + 180) > wrap_360(df_upstream["wd_min"] + 180.0))
-            & (wrap_360(wd + 180) <= wrap_360(df_upstream["wd_max"] + 180)),
-            "turbines",
-        ].values[0]
-
-    # Load data and limit region
-    df = df.copy()
-    pow_cols = ["pow_{:03d}".format(t) for t in turbine_array]
-    df = df.dropna(subset=pow_cols)
-
-    # Filter dataframe and set a reference wd and ws
-    df = dfm.set_wd_by_turbines(df, turb_wd_measurement)
-    df = dfm.filter_df_by_wd(df, [wd - wd_bin_width, wd + wd_bin_width])
-    df = dfm.set_ws_by_turbines(df, turbine_array)
-    df = dfm.filter_df_by_ws(df, [6, 10])
-
-    # Set reference power for df and df_fi as the average power
-    # of all upstream turbines
-    df = dfm.set_pow_ref_by_turbines(df, turbine_array)
-
-    results_scada = []
-    for ti in turbine_array:
-        # Get energy ratios
-        er_out = get_energy_ratio(df, ti, wd)
-        results_scada.append(er_out.df_result)
-
-    results_scada = pd.concat(results_scada)
-    energy_ratios = np.array(results_scada["Raw data (wind direction calibrated)"], dtype=float)
-    energy_ratios_lb = np.array(
-        results_scada["Raw data (wind direction calibrated)_lb"], dtype=float
-    )
-    energy_ratios_ub = np.array(
-        results_scada["Raw data (wind direction calibrated)_ub"], dtype=float
-    )
-
-    return pd.DataFrame(
-        {
-            "wd": [wd],
-            "wd_bin_width": [wd_bin_width],
-            "upstream_turbines": [turbine_array],
-            "energy_ratios": [energy_ratios],
-            "energy_ratios_lb": [energy_ratios_lb],
-            "energy_ratios_ub": [energy_ratios_ub],
-            "ws_ratios": [energy_ratios ** (1 / 3)],
-        }
-    )
-
-
-def _plot_single_wd(df):
-    fig, ax = plt.subplots()
-    turbine_array = df.loc[0, "upstream_turbines"]
-
-    x = range(len(turbine_array))
-    ax.fill_between(
-        x, df.loc[0, "energy_ratios_lb"], df.loc[0, "energy_ratios_ub"], color="k", alpha=0.30
-    )
-    ax.plot(x, df.loc[0, "energy_ratios"], "-o", color="k", label="SCADA")
-    ax.grid(True)
-    ax.set_xticks(x)
-    ax.set_xticklabels(["T{:03d}".format(t) for t in turbine_array])
-    ax.set_ylabel("Energy ratio of upstream turbines w.r.t. the average (-)")
-    ax.set_title("Wind direction = {:.2f} deg.".format(df.loc[0, "wd"]))
-    ax.set_ylim([0.85, 1.20])
-    return fig, ax
-
-
 if __name__ == "__main__":
     # Load FLORIS and plot the layout
     fi, _ = load_floris()
@@ -151,9 +47,7 @@ if __name__ == "__main__":
     # an unreliable wind direction measurement. Here, for explanation purposes,
     # we just exclude turbine 3 from our analysis.
     nturbs = len(fi.layout_x)
-    bad_turbs = [
-        3
-    ]  # Just hypothetical situation: assume turbine 3 gave faulty wind directions so we ignore it
+    bad_turbs = [3]  # Just hypothetical situation: assume turbine 3 gave faulty wind directions so we ignore it
     turb_wd_measurement = [i for i in range(nturbs) if i not in bad_turbs]
 
     # We use a wind direction bin width of 15 deg. Thus, if we look at
@@ -166,18 +60,27 @@ if __name__ == "__main__":
     # using a very simplified model as part of FLASC.
     df_upstream = ftools.get_upstream_turbs_floris(fi, wake_slope=0.3)
 
-    # Finally, for various wind directions, calculate the energy ratios of
+    # Load the FLASC heterogeneity mapper
+    hm = heterogeneity_mapper(df_raw=df_full, fi=fi)
+
+    # For all wind directions from 0 to 360 deg, calculate the energy ratios of
     # all upstream turbines. That gives a good idea of the heterogeneity
     # in the inflow wind speeds. Namely, turbines that consistently see
     # a higher energy ratio, also likely consistently see a higher wind speed.
-    df_list = []
-    for wd in np.arange(0.0, 360.0, 15.0):
-        df = _process_single_wd(wd, wd_bin_width, turb_wd_measurement, df_upstream, df_full)
-        fig, ax = _plot_single_wd(df)  # Plot the results
-        df_list.append(df)
+    df_heterogeneity = hm.estimate_heterogeneity(
+        df_upstream=df_upstream,
+        wd_bin_width=15.0,
+        wd_array=np.arange(0.0, 360.0, 30.0),
+        ws_range=[6.0, 10.0]
+    )
+    print(df_heterogeneity)
+    
+    # Extract a FLORIS heterogeneity map and plot it over the layout
 
-    # Finally merge the results to a single dataframe and print
-    df = pd.concat(df_list).reset_index(drop=True)
-    print(df)
+    df_fi_hetmap = hm.generate_floris_hetmap()
+    hm.plot_layout(plot_background_flow=True, ylim=[0.95, 1.05])
+
+    # Plot individual graphs to showcase heterogeneity
+    hm.plot_graphs()
 
     plt.show()

--- a/examples_artificial_data/03_energy_ratio/05_estimate_heterogeneity_from_energy_ratios.py
+++ b/examples_artificial_data/03_energy_ratio/05_estimate_heterogeneity_from_energy_ratios.py
@@ -1,18 +1,15 @@
 import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from floris.utilities import wrap_360
-
-from flasc.dataframe_operations import dataframe_manipulations as dfm
 from flasc import floris_tools as ftools
-from flasc.energy_ratio import energy_ratio as er
-from flasc.energy_ratio.energy_ratio_input import EnergyRatioInput
+from flasc.dataframe_operations import dataframe_manipulations as dfm
+from flasc.energy_ratio.energy_ratio_heterogeneity_mapper import heterogeneity_mapper
+
 # from flasc.visualization import plot_floris_layout
 from flasc.utilities_examples import load_floris_artificial as load_floris
-
-from flasc.energy_ratio.energy_ratio_heterogeneity_mapper import heterogeneity_mapper
 
 
 def load_data():
@@ -37,13 +34,15 @@ def load_data():
 if __name__ == "__main__":
     # Load FLORIS and plot the layout
     fi, _ = load_floris()
-    
+
     # Now specify which turbines we want to use in the analysis. Basically,
     # we want to use all the turbines besides the ones that we know have
     # an unreliable wind direction measurement. Here, for explanation purposes,
     # we just exclude turbine 3 from our analysis.
     nturbs = len(fi.layout_x)
-    bad_turbs = [3]  # Just hypothetical situation: assume turbine 3 gave faulty wind directions so we ignore it
+    bad_turbs = [
+        3
+    ]  # Just hypothetical situation: assume turbine 3 gave faulty wind directions so we ignore it
     turb_wd_measurement = [i for i in range(nturbs) if i not in bad_turbs]
 
     # Load the SCADA data and assign the freestream wind direction
@@ -72,11 +71,11 @@ if __name__ == "__main__":
         df_upstream=df_upstream,
         wd_bin_width=wd_bin_width,
         wd_array=np.arange(0.0, 360.0, 30.0),
-        ws_range=[6.0, 11.0]
+        ws_range=[6.0, 11.0],
     )
     print("df_heterogeneity:")
     print(df_heterogeneity)
-    
+
     # Extract a FLORIS heterogeneity map
     df_fi_hetmap = hm.generate_floris_hetmap()
     print("")

--- a/examples_artificial_data/03_energy_ratio/05_estimate_heterogeneity_from_energy_ratios.py
+++ b/examples_artificial_data/03_energy_ratio/05_estimate_heterogeneity_from_energy_ratios.py
@@ -9,7 +9,7 @@ from flasc.dataframe_operations import dataframe_manipulations as dfm
 from flasc import floris_tools as ftools
 from flasc.energy_ratio import energy_ratio as er
 from flasc.energy_ratio.energy_ratio_input import EnergyRatioInput
-from flasc.visualization import plot_floris_layout
+# from flasc.visualization import plot_floris_layout
 from flasc.utilities_examples import load_floris_artificial as load_floris
 
 from flasc.energy_ratio.energy_ratio_heterogeneity_mapper import heterogeneity_mapper
@@ -37,9 +37,6 @@ def load_data():
 if __name__ == "__main__":
     # Load FLORIS and plot the layout
     fi, _ = load_floris()
-    plot_floris_layout(fi, plot_terrain=False)
-
-
     
     # Now specify which turbines we want to use in the analysis. Basically,
     # we want to use all the turbines besides the ones that we know have
@@ -77,10 +74,13 @@ if __name__ == "__main__":
         wd_array=np.arange(0.0, 360.0, 30.0),
         ws_range=[6.0, 11.0]
     )
+    print("df_heterogeneity:")
     print(df_heterogeneity)
     
     # Extract a FLORIS heterogeneity map
     df_fi_hetmap = hm.generate_floris_hetmap()
+    print("")
+    print("df_fi_map:")
     print(df_fi_hetmap)
 
     # Generate a heterogeneity contour plot over the turbine layout plot
@@ -90,5 +90,4 @@ if __name__ == "__main__":
 
     # Plot individual graphs to showcase heterogeneity in detail
     hm.plot_graphs()
-
     plt.show()

--- a/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
+++ b/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
@@ -1,4 +1,6 @@
+from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
+
 import numpy as np
 import pandas as pd
 from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
@@ -133,7 +135,7 @@ class heterogeneity_mapper():
             raise UserWarning("Please call 'estimate_heterogeneity(...)' first.")
 
         if pdf_save_path is not None:
-            pdf = matplotlib.backends.backend_pdf.PdfPages(pdf_save_path)
+            pdf = PdfPages(pdf_save_path)
 
         # Plot the results one by one
         for _, df_row in self.df_heterogeneity.iterrows():
@@ -233,7 +235,7 @@ class heterogeneity_mapper():
             raise UserWarning("Please call 'generate_floris_hetmap(...)' first.")
 
         if pdf_save_path is not None:
-            pdf = matplotlib.backends.backend_pdf.PdfPages(pdf_save_path)
+            pdf = PdfPages(pdf_save_path)
 
         # Plot the results one by one
         fi = self.fi

--- a/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
+++ b/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
@@ -235,15 +235,6 @@ class heterogeneity_mapper:
 
         # Plot the results one by one
         fi = self.fi
-        plotting_dict = {
-            "turbine_indices": range(len(fi.layout_x)),
-            "turbine_names": ["T{:02d}".format(X) for X in range(len(fi.layout_x))],
-            "color": ("lightgray"),
-            "marker": ("."),
-            "markersize": (30),
-            "label": (None),
-        }
-
         for _, df_row in self.df_heterogeneity.iterrows():
             non_upstream_turbines = [
                 ti for ti in range(len(fi.layout_x)) if ti not in df_row["upstream_turbines"]

--- a/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
+++ b/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
@@ -149,7 +149,6 @@ class heterogeneity_mapper:
             )
             ax.plot(x, df_row["energy_ratios"], "-o", color="k", label="SCADA")
             ax.grid(True, which="major")
-            # ax.grid(True, which="minor", axis="y")
             ax.set_ylabel("Energy ratio of upstream \n turbines w.r.t. the average (-)")
             ax.set_title("Wind direction = {:.1f} deg. Bin count: {:d}.".format(wd, N))
             ax.set_ylim(ylim)
@@ -210,13 +209,6 @@ class heterogeneity_mapper:
             locations_x.append(xlocs)
             locations_y.append(ylocs)
             speed_ups.append(speedup_onewd)
-
-            # fig, ax = plt.subplots()
-            # ax.plot(xlocs, ylocs, '.')
-            # ax.plot(x_turbs, y_turbs, 'ro')
-            # im = ax.tricontourf(xlocs, ylocs, speedup_onewd, levels=50)
-            # plt.colorbar(im)
-            # plt.show()
 
         df_fi_hetmap = pd.DataFrame(
             {
@@ -361,14 +353,6 @@ class heterogeneity_mapper:
                 im = ax.tricontourf(
                     x, y, het_map_mesh, cmap="jet", vmin=ylim[0], vmax=ylim[1], levels=50, zorder=-1
                 )
-                # ax.scatter(
-                #     self.df_fi_hetmap.loc[0]["x"],
-                #     self.df_fi_hetmap.loc[0]["y"],
-                #     c=self.df_fi_hetmap.loc[0].speed_up,
-                #     cmap="jet",
-                #     vmin=ylim[0],
-                #     vmax=ylim[1],
-                # )
 
             if pdf_save_path is not None:
                 pdf.savefig(fig)

--- a/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
+++ b/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
@@ -320,15 +320,12 @@ class heterogeneity_mapper:
                 )
                 x = x.flatten()
                 y = y.flatten()
-                try:
-                    lin_interpolant = LinearNDInterpolator(
-                        points=np.vstack([df_hetmap_row["x"], df_hetmap_row["y"]]).T,
-                        values=df_hetmap_row["speed_up"],
-                        fill_value=np.nan,
-                    )
-                    lin_values = lin_interpolant(x, y)
-                except:
-                    lin_values = np.nan * np.ones_like(x)
+                lin_interpolant = LinearNDInterpolator(
+                    points=np.vstack([df_hetmap_row["x"], df_hetmap_row["y"]]).T,
+                    values=df_hetmap_row["speed_up"],
+                    fill_value=np.nan,
+                )
+                lin_values = lin_interpolant(x, y)
 
                 nearest_interpolant = NearestNDInterpolator(
                     x=np.vstack([df_hetmap_row["x"], df_hetmap_row["y"]]).T,

--- a/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
+++ b/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
@@ -1,0 +1,369 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.interpolate import NearestNDInterpolator
+
+from floris.utilities import wrap_360
+
+from flasc.dataframe_operations import dataframe_manipulations as dfm
+from flasc.energy_ratio import energy_ratio as er
+from flasc.energy_ratio.energy_ratio_input import EnergyRatioInput
+
+
+# Standalone function to easily extract energy ratios for narrow wind direction bin
+def _get_energy_ratio(df, ti, wd_bins, ws_range):
+    # Calculate energy ratios
+    er_in = EnergyRatioInput([df], ['data'])
+    return er.compute_energy_ratio(
+            er_in,
+            test_turbines=[ti],
+            use_predefined_ref=True,
+            use_predefined_wd=True,
+            use_predefined_ws=True,
+            wd_step=15.0,
+            wd_bin_overlap_radius=0.0,
+            wd_min=wd_bins[0][0],
+            wd_max=wd_bins[0][1],
+            ws_min=ws_range[0],
+            ws_max=ws_range[1],
+            N=10,
+            percentiles=[5.0, 95.0]
+        )
+
+
+# Heterogeneity mapper class with all internal functions to calculate, extract and plot heterogeneity
+# derived from upstream turbine's power measurements
+class heterogeneity_mapper():
+    """This class is useful to calculate the energy ratios of a set
+    of upstream turbines to then derive the heterogeneity in the
+    inflow wind speed. This can be helpful in characterizing the
+    ambient wind speed distribution for operational assets where
+    we do not have such information. Note that heterogeneity may
+    come from multiple sources, not only neighboring farms but also
+    blockage effects of the farm itself.
+    """
+   
+    # Private functions
+    def __init__(self, df_raw, fi):
+        # Save to self
+        self.df_raw = df_raw
+        self.fi = fi
+        self.df_heterogeneity = None
+        self.df_fi_hetmap = None
+
+    def _process_single_wd(self, wd, wd_bin_width, ws_range, df_upstream):
+        # In this function, we calculate the energy ratios of all upstream
+        # turbines for a single wind direction bin and single wind speed bin.
+        # The difference in energy ratios between different upstream turbines
+        # gives a strong indication of the heterogeneity in the inflow wind
+        # speeds for that mean inflow wind direction.
+        print("Processing wind direction = {:.1f} deg.".format(wd))
+        wd_bins = [[wd - wd_bin_width / 2.0, wd + wd_bin_width / 2.0]]
+
+        # Determine which turbines are upstream
+        if wd > df_upstream.iloc[0]["wd_max"]:
+            turbine_array = df_upstream.loc[
+                (wd > df_upstream["wd_min"]) & (wd <= df_upstream["wd_max"]),
+                "turbines"
+            ].values[0]
+
+        # deal with wd = 0 deg (or close to 0.0)
+        else:
+            turbine_array = df_upstream.loc[
+                (wrap_360(wd + 180) > wrap_360(df_upstream["wd_min"] + 180.0)) &
+                (wrap_360(wd + 180) <= wrap_360(df_upstream["wd_max"] + 180)),
+                "turbines"
+            ].values[0]
+
+        # Load data and limit region
+        df = self.df_raw.copy()
+        pow_cols = ["pow_{:03d}".format(t) for t in turbine_array]
+        df = df.dropna(subset=pow_cols)
+
+        # Filter dataframe and set a reference wd and ws
+        df = dfm.filter_df_by_wd(df, [wd - wd_bin_width, wd + wd_bin_width])
+        df = dfm.set_ws_by_turbines(df, turbine_array)
+        df = dfm.filter_df_by_ws(df, ws_range)
+
+        # Set reference power for df and df_fi as the average power
+        # of all upstream turbines
+        df = dfm.set_pow_ref_by_turbines(df, turbine_array)
+        df = df.dropna(subset=["wd", "ws", "pow_ref"])
+
+        results_scada = []
+        for ti in turbine_array:
+            # Get energy ratios
+            er = _get_energy_ratio(df, ti, wd_bins, ws_range)
+            results_scada.append(er.df_result.loc[0])
+
+        results_scada = pd.concat(results_scada, axis=1).T
+        energy_ratios = np.array(results_scada["data"], dtype=float)
+        energy_ratios_lb = np.array(results_scada["data_lb"], dtype=float)
+        energy_ratios_ub = np.array(results_scada["data_ub"], dtype=float)
+
+        return pd.DataFrame({
+                "wd": [wd],
+                "wd_bin_width": [wd_bin_width],
+                "upstream_turbines": [turbine_array],
+                "energy_ratios": [energy_ratios],
+                "energy_ratios_lb": [energy_ratios_lb],
+                "energy_ratios_ub": [energy_ratios_ub],
+                "ws_ratios": [energy_ratios**(1/3)],
+                "bin_count": [np.array(results_scada["count_data"], dtype=int)]
+        })
+
+    
+    # Public functions
+    def estimate_heterogeneity(
+            self,
+            df_upstream,
+            wd_array=np.arange(0.0, 360.0, 3.0),
+            wd_bin_width=6.0,
+            ws_range=[6.0, 11.0],
+        ):
+        df_list = [
+            self._process_single_wd(wd, wd_bin_width, ws_range, df_upstream)
+            for wd in wd_array
+        ]
+        self.df_heterogeneity = pd.concat(df_list).reset_index(drop=True)
+        return self.df_heterogeneity
+
+    def plot_graphs(self, ylim=[0.8, 1.2], pdf_save_path=None):
+        if self.df_heterogeneity is None:
+            raise UserWarning("Please call 'estimate_heterogeneity(...)' first.")
+
+        if pdf_save_path is not None:
+            pdf = matplotlib.backends.backend_pdf.PdfPages(pdf_save_path)
+
+        # Plot the results one by one
+        for _, df_row in self.df_heterogeneity.iterrows():
+            fig, ax = plt.subplots(figsize=(7, 4))
+            turbine_array = df_row["upstream_turbines"]
+
+            wd = df_row["wd"]
+            N = df_row["bin_count"][0]
+
+            x = range(len(turbine_array))
+            ax.fill_between(
+                x,
+                df_row["energy_ratios_lb"],
+                df_row["energy_ratios_ub"],
+                color="k",
+                alpha=0.30
+            )
+            ax.plot(x, df_row["energy_ratios"], "-o", color='k', label="SCADA")
+            ax.grid(True, which="major")
+            # ax.grid(True, which="minor", axis="y")
+            ax.set_ylabel("Energy ratio of upstream \n turbines w.r.t. the average (-)")
+            ax.set_title("Wind direction = {:.1f} deg. Bin count: {:d}.".format(wd, N))
+            ax.set_ylim(ylim)
+            ax.set_xticks(x)
+            ax.set_yticks(np.arange(ylim[0] - 0.05, ylim[1] + 0.05, 0.10))
+            plt.minorticks_on()
+            ax.set_xticklabels(["T{:03d}".format(t) for t in turbine_array])
+            ax.set_yticklabels(["{:.2f}".format(f) for f in ax.get_yticks()])
+
+            ax2 = ax.twinx()
+            ax2.plot(x, df_row["energy_ratios"], "-o", color='orange', label="SCADA") 
+            ax2.set_ylim(ax.get_ylim())
+            ax2.set_yticks(ax.get_yticks())
+            ax2.set_yticklabels(["{:.2f}".format(np.cbrt(f)) for f in ax.get_yticks()], color="orange")
+            ax2.set_ylabel("WS ratio of upstream \n turbines w.r.t. the average (-)", color="orange")
+
+            plt.tight_layout()
+
+            if pdf_save_path is not None:
+                pdf.savefig(fig)
+                plt.close("all")
+
+        if pdf_save_path is not None:
+            print("Plots saved to '{:s}'.".format(pdf_save_path))
+            pdf.close()
+
+    def generate_floris_hetmap(self):
+        if self.df_heterogeneity is None:
+            raise UserWarning("Please call 'estimate_heterogeneity(...)' first.")
+        
+        # Determine FLORIS heterogeneous map
+        fi = self.fi
+        ll = np.sqrt(
+            (np.max(fi.layout_x) - np.min(fi.layout_x))**2.0 +
+            (np.max(fi.layout_y) - np.min(fi.layout_y))**2.0
+        )
+        locations_x = []
+        locations_y = []
+        speed_ups = []
+        for ii in range(self.df_heterogeneity.shape[0]):
+            df_row = self.df_heterogeneity.loc[ii]
+            turbs = df_row["upstream_turbines"]
+            wd = (270.0 - df_row["wd"]) * np.pi / 180.0
+            x_turbs = np.array(fi.layout_x, dtype=float)[turbs]
+            y_turbs = np.array(fi.layout_y, dtype=float)[turbs]
+
+            xlocs = np.hstack([xt + ll * np.cos(wd) * np.linspace(-1.0, 1.0, 100) for xt in x_turbs])
+            ylocs = np.hstack([yt + ll * np.sin(wd) * np.linspace(-1.0, 1.0, 100) for yt in y_turbs])
+            speedup_onewd = np.repeat(df_row["ws_ratios"], 100)
+            locations_x.append(xlocs)
+            locations_y.append(ylocs)
+            speed_ups.append(speedup_onewd)
+
+            # fig, ax = plt.subplots()
+            # ax.plot(xlocs, ylocs, '.')
+            # ax.plot(x_turbs, y_turbs, 'ro')
+            # im = ax.tricontourf(xlocs, ylocs, speedup_onewd, levels=50)
+            # plt.colorbar(im)
+            # plt.show()
+
+        df_fi_hetmap = pd.DataFrame({
+            "wd": self.df_heterogeneity["wd"],
+            "x": locations_x,
+            "y": locations_y,
+            "speed_up": speed_ups
+        })
+
+        self.df_fi_hetmap = df_fi_hetmap
+        return df_fi_hetmap
+
+    # # Visualization
+    def plot_layout(self, ylim=[0.8, 1.2], plot_background_flow=False, pdf_save_path=None):
+        if self.df_heterogeneity is None:
+            raise UserWarning("Please call 'estimate_heterogeneity(...)' first.")
+
+        if plot_background_flow and self.df_fi_hetmap is None:
+            raise UserWarning("Please call 'generate_floris_hetmap(...)' first.")
+
+        if pdf_save_path is not None:
+            pdf = matplotlib.backends.backend_pdf.PdfPages(pdf_save_path)
+
+        # Plot the results one by one
+        fi = self.fi
+        plotting_dict = {
+            "turbine_indices": range(len(fi.layout_x)),
+            "turbine_names": ["T{:02d}".format(X) for X in range(len(fi.layout_x))],
+            "color": ("lightgray"),
+            "marker": ("."),
+            "markersize": (30),
+            "label": (None)
+        }
+
+        for _, df_row in self.df_heterogeneity.iterrows():
+            non_upstream_turbines = [ti for ti in range(len(fi.layout_x)) if ti not in df_row["upstream_turbines"]]
+
+            fig, ax = plt.subplots(figsize=(8, 6))
+            ax.scatter(
+                x=fi.layout_x[non_upstream_turbines],
+                y=fi.layout_y[non_upstream_turbines],
+                s=300,
+                c="lightgray",
+            )
+            for ti in non_upstream_turbines:
+                ax.text(fi.layout_x[ti], fi.layout_y[ti], "T{:02d}".format(ti))
+
+            im = ax.scatter(
+                x=fi.layout_x[df_row["upstream_turbines"]],
+                y=fi.layout_y[df_row["upstream_turbines"]],
+                c=df_row["ws_ratios"],
+                s=300,
+                cmap="jet",
+                vmin=ylim[0],
+                vmax=ylim[1],
+                edgecolor="black",
+            )
+            for ii, ti in enumerate(df_row["upstream_turbines"]):
+                ax.text(
+                    fi.layout_x[ti],
+                    fi.layout_y[ti],
+                    "T{:02d} ({:+.1f}%)".format(ti, 100.0 * (df_row["ws_ratios"][ii] - 1.0)),
+                    weight="bold",
+                )
+
+            # Add arrow plot
+            xm = np.min(fi.layout_x) - 100.0
+            ym = np.max(fi.layout_y) + 500.0
+            radius = 120.0
+            theta = np.linspace(0.0, 2*np.pi, 100)
+            xcirc = np.cos(theta) * radius + xm
+            ycirc = np.sin(theta) * radius + ym
+            ax.plot(xcirc, ycirc, color="black", linewidth=2)
+            plt.arrow(
+                x=xm,
+                y=ym,
+                dx=np.cos(-(df_row["wd"] - 270.0) * np.pi / 180.0) * radius,
+                dy=np.sin(-(df_row["wd"] - 270.0) * np.pi / 180.0) * radius,
+                width=0.125 * radius,
+                head_width=0.6 * radius,
+                head_length=0.75 * radius,
+                length_includes_head=True,
+                color="black"
+            )
+
+            # Add title, colorbar
+            ax.set_title("Wind direction: {:.1f} deg".format(df_row["wd"]))
+            clb = plt.colorbar(im, ax=ax)
+            clb.set_label("Wind speed ratio (-)")
+
+            # Add plot to ensure equal axis does not crop plot too much
+            ax.plot(np.max(fi.layout_x) + 500.0, np.min(fi.layout_y), '.', color='white')
+            ax.axis("equal")
+            plt.tight_layout()
+
+            if plot_background_flow:
+                df_hetmap = self.df_fi_hetmap
+                id_hetmap = np.where(df_hetmap["wd"] == df_row["wd"])[0][0]
+                df_hetmap_row = df_hetmap.loc[id_hetmap]
+
+                if len(np.unique(df_hetmap_row["speed_up"])) <= 1:
+                    # Add some noise to prevent issues
+                    df_hetmap_row = df_hetmap_row.copy()
+                    df_hetmap_row["speed_up"] += 0.0001 * np.random.randn(len(df_hetmap_row["speed_up"]))
+
+                xlim_plot = ax.get_xlim()
+                ylim_plot = ax.get_ylim()
+                x, y = np.meshgrid(
+                    np.linspace(xlim_plot[0], xlim_plot[1], 100),
+                    np.linspace(ylim_plot[0], ylim_plot[1], 100),
+                    indexing="ij"
+                )
+                x = x.flatten()
+                y = y.flatten()
+                try:
+                    lin_interpolant = LinearNDInterpolator(
+                        points=np.vstack([df_hetmap_row["x"], df_hetmap_row["y"]]).T,
+                        values=df_hetmap_row["speed_up"],
+                        fill_value=np.nan
+                    )
+                    lin_values = lin_interpolant(x, y)
+                except:
+                    lin_values = np.nan * np.ones_like(x)
+
+                nearest_interpolant = NearestNDInterpolator(
+                    x=np.vstack([df_hetmap_row["x"], df_hetmap_row["y"]]).T,
+                    y=df_hetmap_row["speed_up"],
+                )
+                nn_values = nearest_interpolant(x,y)
+                ids_isnan = np.isnan(lin_values)
+
+                het_map_mesh = np.array(lin_values, copy=True)
+                het_map_mesh[ids_isnan] = nn_values[ids_isnan]
+
+                # Produce plot
+                im = ax.tricontourf(
+                    x,
+                    y,
+                    het_map_mesh,
+                    cmap="jet",
+                    vmin=ylim[0],
+                    vmax=ylim[1],
+                    levels=50,
+                    zorder=-1
+                )
+
+            if pdf_save_path is not None:
+                pdf.savefig(fig)
+                plt.close("all")
+
+        if pdf_save_path is not None:
+            print("Plots saved to '{:s}'.".format(pdf_save_path))
+            pdf.close()
+
+        return fig, ax

--- a/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
+++ b/flasc/energy_ratio/energy_ratio_heterogeneity_mapper.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from scipy.interpolate import NearestNDInterpolator
+from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
 
 from floris.utilities import wrap_360
 
@@ -186,7 +186,7 @@ class heterogeneity_mapper():
         
         # Determine FLORIS heterogeneous map
         fi = self.fi
-        ll = np.sqrt(
+        ll = 2.0 * np.sqrt(
             (np.max(fi.layout_x) - np.min(fi.layout_x))**2.0 +
             (np.max(fi.layout_y) - np.min(fi.layout_y))**2.0
         )
@@ -303,18 +303,17 @@ class heterogeneity_mapper():
             clb.set_label("Wind speed ratio (-)")
 
             # Add plot to ensure equal axis does not crop plot too much
-            ax.plot(np.max(fi.layout_x) + 500.0, np.min(fi.layout_y), '.', color='white')
+            ax.plot(np.max(fi.layout_x) + 500.0, np.min(fi.layout_y), '.', color='white', markersize=1)
             ax.axis("equal")
             plt.tight_layout()
 
             if plot_background_flow:
-                df_hetmap = self.df_fi_hetmap
+                df_hetmap = self.df_fi_hetmap.copy()
                 id_hetmap = np.where(df_hetmap["wd"] == df_row["wd"])[0][0]
                 df_hetmap_row = df_hetmap.loc[id_hetmap]
 
                 if len(np.unique(df_hetmap_row["speed_up"])) <= 1:
                     # Add some noise to prevent issues
-                    df_hetmap_row = df_hetmap_row.copy()
                     df_hetmap_row["speed_up"] += 0.0001 * np.random.randn(len(df_hetmap_row["speed_up"]))
 
                 xlim_plot = ax.get_xlim()
@@ -357,6 +356,14 @@ class heterogeneity_mapper():
                     levels=50,
                     zorder=-1
                 )
+                # ax.scatter(
+                #     self.df_fi_hetmap.loc[0]["x"],
+                #     self.df_fi_hetmap.loc[0]["y"],
+                #     c=self.df_fi_hetmap.loc[0].speed_up,
+                #     cmap="jet",
+                #     vmin=ylim[0],
+                #     vmax=ylim[1],
+                # )
 
             if pdf_save_path is not None:
                 pdf.savefig(fig)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
This PR is ready to be merged.

**Feature or improvement description**
This PR adds a separate class for the heterogeneity estimation process, including automatic conversion to FLORIS' `het_map` variable and various visualizations.

**Related issue, if one exists**
N/A

**Impacted areas of the software**
Energy ratio class.

**Additional supporting information**
This class is useful for quickly deriving the heterogeneous inflow profiles over all wind directions and formatting it to a FLORIS-compatible format. The class allows you to directly output the heterogeneity profiles to a FLORIS-compatible format so that it can be used in the `het_map` variable. Note that this function linearly extends the measured heterogeneous wind speeds along the wind direction:

![image](https://github.com/NREL/flasc/assets/22119448/c23287b3-1f5c-468f-92e6-3889b1185ca6)


**Test results, if applicable**
The example `05_estimate_heterogeneity_from_energy_ratios.py` now produces the figures:
![image](https://github.com/NREL/flasc/assets/22119448/7c4aa773-1dee-49f9-b558-11ba4695107b)

![image](https://github.com/NREL/flasc/assets/22119448/32e7a86d-9694-4878-a370-2fcd1897fd9b)

![image](https://github.com/NREL/flasc/assets/22119448/b129f6c7-00be-4329-8867-4b0b3fc24795)

and this is how the variable `df_fi_hetmap` looks like in the example:

```
       wd                                                  x                                                  y                                           speed_up
0     0.0  [755.9380000000007, 755.9380000000007, 755.938...  [4183.320249119671, 4110.435880450586, 4037.55...  [0.9998389989397772, 0.9998389989397772, 0.999...
1    30.0  [3434.1101245598365, 3397.667940225294, 3361.2...  [3124.4258829077685, 3061.306168101551, 2998.1...  [1.0007038336839695, 1.0007038336839695, 1.000...
2    60.0  [4754.64788290777, 4691.528168101552, 4628.408...  [1803.8881245598357, 1767.4459402252935, 1731....  [0.9997069479189234, 0.9997069479189234, 0.999...
3    90.0  [5237.998249119671, 5165.113880450586, 5092.22...  [-4.4182516355242484e-13, -4.3289940267257786e...  [0.9667388379485943, 0.9667388379485943, 0.966...
4   120.0  [4754.64788290777, 4691.528168101552, 4628.408...  [-1803.8881245598348, -1767.4459402252926, -17...  [0.9980607757391102, 0.9980607757391102, 0.998...
5   150.0  [3434.1101245598343, 3397.667940225292, 3361.2...  [-3124.4258829077703, -3061.306168101553, -299...  [1.000333827309378, 1.000333827309378, 1.00033...
6   180.0  [1630.2219999999998, 1630.2219999999998, 1630....  [-3607.7762491196704, -3534.891880450586, -346...  [1.0004001118062382, 1.0004001118062382, 1.000...
7   210.0  [-173.66612455983568, -137.22394022529352, -10...  [-3124.4258829077694, -3061.306168101552, -299...  [0.9997574896290464, 0.9997574896290464, 0.999...
8   240.0  [-1494.2038829077699, -1431.0841681015525, -13...  [-1803.8881245598348, -1767.4459402252926, -17...  [1.000689792658521, 1.000689792658521, 1.00068...
9   270.0  [-2791.3872491196703, -2718.502880450586, -264...  [123.431, 123.431, 123.431, 123.431, 123.431, ...  [0.9993868881890051, 0.9993868881890051, 0.999...
10  300.0  [-3124.42588290777, -3061.3061681015524, -2998...  [2451.6671245598345, 2415.224940225293, 2378.7...  [1.000499654613084, 1.000499654613084, 1.00049...
11  330.0  [-1047.9501245598358, -1011.5079402252935, -97...  [3699.9698829077693, 3636.850168101552, 3573.7...  [1.0006043428343852, 1.0006043428343852, 1.000...
```
<!-- Release checklist:
- Update the version in
    - [ ] docs/source/conf.py
    - [ ] flasc/VERSION
- [ ] Create a tag in the NREL/FLASC repository
-->
