### PR TITLE
Feature: Identify impacting turbines geometrically and reduce FLORIS accordingly

### DIFF
--- a/examples_artificial_data/00_setup_floris_model/04_geometric_dependencies.py
+++ b/examples_artificial_data/00_setup_floris_model/04_geometric_dependencies.py
@@ -1,0 +1,57 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from floris.tools import FlorisInterface
+
+from flasc.floris_tools import get_all_impacting_turbines_geometrical
+
+# Demonstrate the get_all_impacting_turbines_geometrical
+# function in floris_tools
+
+# Load a large FLORIS object
+fi = FlorisInterface("../floris_input_artificial/gch.yaml")
+D = 126.0
+X, Y = np.meshgrid(7.0 * D * np.arange(20), 5.0 * D * np.arange(20))
+fi.reinitialize(layout_x=X.flatten(), layout_y=Y.flatten())
+
+# Specify which turbines are of interest
+turbine_weights = np.zeros(len(X.flatten()), dtype=float)
+turbine_weights[np.hstack([a + range(10) for a in np.arange(50, 231, 20)])] = 1.0
+
+# Get all impacting turbines for each wind direction using simple geometry rules
+df_impacting = get_all_impacting_turbines_geometrical(
+    fi=fi, turbine_weights=turbine_weights, wd_array=np.arange(0.0, 360.0, 30.0)
+)
+
+# Produce plots showcasing which turbines are estimated to be impacting
+for ii in range(df_impacting.shape[0]):
+    wd = df_impacting.loc[ii, "wd"]
+
+    fig, ax = plt.subplots()
+    ax.plot(fi.layout_x, fi.layout_y, "o", color="lightgray", label="All turbines")
+
+    ids = df_impacting.loc[ii, "impacting_turbines"]
+    no_turbines_total = len(fi.layout_x)
+    no_turbines_reduced = len(ids)
+    ax.plot(fi.layout_x[ids], fi.layout_y[ids], "o", color="black", label="Impacting turbines")
+
+    ids = np.where(turbine_weights > 0.001)[0]
+    ax.plot(fi.layout_x[ids], fi.layout_y[ids], "o", color="red", label="Turbines of interest")
+
+    ax.set_xlabel("X location (m)")
+    ax.set_ylabel("Y location (m)")
+    ax.axis("equal")
+    ax.grid(True)
+    ax.legend()
+    percentage = 100.0 * no_turbines_reduced / no_turbines_total
+    ax.set_title(
+        f"Wind direction: {wd:.1f} deg. Turbines modelled: "
+        f"{no_turbines_reduced:d}/{no_turbines_total} ({percentage:.1f}%)."
+    )
+
+    # Make a statement on number of wake-steered turbines vs. total farm size
+    print(
+        f"wd={wd:.1f} deg. Reduced from {no_turbines_total:d} "
+        f"to {no_turbines_reduced} ({percentage:.1f}%)."
+    )
+
+plt.show()

--- a/flasc/floris_tools.py
+++ b/flasc/floris_tools.py
@@ -91,7 +91,7 @@ def merge_floris_objects(fi_list, reference_wind_height=None):
     return fi_merged
 
 
-def reduce_floris_object(fi, turbine_list):
+def reduce_floris_object(fi, turbine_list, copy=False):
     """Reduce a large FLORIS object to a subset selection of wind turbines.
 
     Args:
@@ -101,6 +101,12 @@ def reduce_floris_object(fi, turbine_list):
     Returns:
         fi_reduced (FlorisInterface): The reduced FlorisInterface object.
     """
+
+    # Copy, if necessary
+    if copy:
+        fi_reduced = fi.copy()
+    else:
+        fi_reduced = fi
 
     # Get the turbine locations from the floris object
     x = np.array(fi.layout_x, dtype=float, copy=True)
@@ -631,7 +637,12 @@ def get_turbs_in_radius(
     return turbs_within_radius
 
 
-def get_all_impacting_turbines_geometrical(fi, turbine_weights, wd_step=3.0, wake_slope=0.30):
+def get_all_impacting_turbines_geometrical(
+    fi,
+    turbine_weights,
+    wd_array=np.arange(0.0, 360.0, 3.0),
+    wake_slope=0.30
+):
     """Determine which turbines affect the turbines of interest
     (i.e., those with a turbine_weights > 0.00001). This function
     uses very simplified geometric functions to very quickly
@@ -672,7 +683,6 @@ def get_all_impacting_turbines_geometrical(fi, turbine_weights, wd_step=3.0, wak
 
     # Rotate farm and determine freestream/waked turbines
     is_impacting_list = []
-    wd_array = np.arange(0.0, 360.0, wd_step)
     for wd in wd_array:
         is_impacting = [None for _ in range(n_turbs)]
         


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
This PR is ready to be merged, but may require examples.

**Feature or improvement description**
This function, through very simplified geometry (linear wake expansion, not modeling deficit), identifies which turbines are impacting a set of "turbines of interest". This can be helpful when you are trying to identify which neighboring wind farms affect your farm of interest for a particular wind direction. This function runs in a matter of seconds, vs. the current function which runs FLORIS simulations and can take hours for large farms. At times, this reduction can cut down the size of your FLORIS model by more than 50% and thereby give you massive speed-ups.

**Related issue, if one exists**
N/A

**Impacted areas of the software**
FLORIS tools.

**Additional supporting information**
N/A

**Test results, if applicable**
This still requires a simple example.

<!-- Release checklist:
- Update the version in
    - [ ] docs/source/conf.py
    - [ ] flasc/VERSION
- [ ] Create a tag in the NREL/FLASC repository
-->
