### PR TITLE
Remove pyproj as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ REQUIRED = [
     "matplotlib~=3.8",
     "numpy~=1.20",
     "pandas~=2.0",
-    "pyproj~=3.0",
     "SALib~=1.0",
     "scipy~=1.1",
     "streamlit~=1.0",


### PR DESCRIPTION
# Remove pyproj as requirement

pyproj currently is given as a requirement, but is not used in the code.  This is a little inconvenient because of issues connecting to package mangement:

https://github.com/astral-sh/uv/issues/8177

This pull request removes it.