### PR TITLE
Finish FlascDataFrame (Paul)

### DIFF
--- a/flasc/analysis/energy_ratio_input.py
+++ b/flasc/analysis/energy_ratio_input.py
@@ -1,5 +1,7 @@
 """Energy ratio input module."""
 
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/flasc/analysis/energy_ratio_input.py
+++ b/flasc/analysis/energy_ratio_input.py
@@ -7,6 +7,7 @@ import pandas as pd
 import polars as pl
 
 from flasc.data_processing.dataframe_manipulations import df_reduce_precision
+from flasc.flasc_dataframe import FlascDataFrame
 
 
 def generate_block_list(N: int, num_blocks: int = 10):
@@ -47,14 +48,15 @@ class EnergyRatioInput:
 
     def __init__(
         self,
-        df_list_in: List[pd.DataFrame],
+        df_list_in: List[pd.DataFrame | FlascDataFrame],
         df_names: List[str],
         num_blocks: int = 10,
     ) -> None:
         """Initialize the EnergyRatioInput class.
 
         Args:
-            df_list_in (List[pd.DataFrame]): A list of pandas dataframes to be concatenated
+            df_list_in (List[pd.DataFrame | FlascDataFrame]): A list of pandas dataframes
+                or FlascDataFrames to be used in analysis
             df_names (List[str]): A list of names for the dataframes
             num_blocks (int): The number of blocks to use for the energy ratio calculation.
                 Defaults to 10.

--- a/flasc/data_processing/dataframe_manipulations.py
+++ b/flasc/data_processing/dataframe_manipulations.py
@@ -324,7 +324,9 @@ def _set_col_by_upstream_turbines_in_radius(
 
 
 # Helper functions
-def set_wd_by_turbines(df, turbine_numbers):
+def set_wd_by_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame], turbine_numbers: List[int]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add WD column by list of turbines.
 
     Add a column called 'wd' in your dataframe with value equal
@@ -345,7 +347,9 @@ def set_wd_by_turbines(df, turbine_numbers):
     return _set_col_by_turbines("wd", "wd", df, turbine_numbers, True)
 
 
-def set_wd_by_all_turbines(df):
+def set_wd_by_all_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame],
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add a wind direction column using all turbines.
 
     Add a column called 'wd' in your dataframe with value equal
@@ -364,7 +368,14 @@ def set_wd_by_all_turbines(df):
     return _set_col_by_turbines("wd", "wd", df, "all", True)
 
 
-def set_wd_by_radius_from_turbine(df, turb_no, x_turbs, y_turbs, max_radius, include_itself=True):
+def set_wd_by_radius_from_turbine(
+    df: Union[pd.DataFrame, FlascDataFrame],
+    turb_no: int,
+    x_turbs: List[float],
+    y_turbs: List[float],
+    max_radius: float,
+    include_itself: bool = True,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add wind direction column by turbines in radius.
 
     Add a column called 'wd' to your dataframe, which is the
@@ -402,7 +413,9 @@ def set_wd_by_radius_from_turbine(df, turb_no, x_turbs, y_turbs, max_radius, inc
     )
 
 
-def set_ws_by_turbines(df, turbine_numbers):
+def set_ws_by_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame], turbine_numbers: List[int]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add ws column by list of turbines.
 
     Add a column called 'ws' in your dataframe with value equal
@@ -423,7 +436,9 @@ def set_ws_by_turbines(df, turbine_numbers):
     return _set_col_by_turbines("ws", "ws", df, turbine_numbers, False)
 
 
-def set_ws_by_all_turbines(df):
+def set_ws_by_all_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame],
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add ws column by all turbines.
 
     Add a column called 'ws' in your dataframe with value equal
@@ -444,7 +459,9 @@ def set_ws_by_all_turbines(df):
     return _set_col_by_turbines("ws", "ws", df, "all", False)
 
 
-def set_ws_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
+def set_ws_by_upstream_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame], df_upstream, exclude_turbs=[]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add wind speed column using upstream turbines.
 
     Add a column called 'ws' in your dataframe with value equal
@@ -481,8 +498,14 @@ def set_ws_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
 
 
 def set_ws_by_upstream_turbines_in_radius(
-    df, df_upstream, turb_no, x_turbs, y_turbs, max_radius, include_itself=True
-):
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    turb_no: int,
+    x_turbs: List[float],
+    y_turbs: List[float],
+    max_radius: float,
+    include_itself: bool = True,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add wind speed column using in-radius upstream turbines.
 
     Add a column called 'ws' to your dataframe, which is the
@@ -529,8 +552,14 @@ def set_ws_by_upstream_turbines_in_radius(
 
 
 def set_ws_by_n_closest_upstream_turbines(
-    df, df_upstream, turb_no, x_turbs, y_turbs, exclude_turbs=[], N=5
-):
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    turb_no: int,
+    x_turbs: List[float],
+    y_turbs: List[float],
+    exclude_turbs: List[int] = [],
+    N: int = 5,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add wind speed column by N closest upstream turbines.
 
     Add a column called 'ws' to your dataframe, which is the
@@ -572,7 +601,9 @@ def set_ws_by_n_closest_upstream_turbines(
     )
 
 
-def set_ti_by_turbines(df, turbine_numbers):
+def set_ti_by_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame], turbine_numbers: List[int]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add TI column by list of turbines.
 
     Add a column called 'ti' in your dataframe with value equal
@@ -593,7 +624,9 @@ def set_ti_by_turbines(df, turbine_numbers):
     return _set_col_by_turbines("ti", "ti", df, turbine_numbers, False)
 
 
-def set_ti_by_all_turbines(df):
+def set_ti_by_all_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame],
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add TI column using all turbines.
 
     Add a column called 'ti' in your dataframe with value equal
@@ -614,7 +647,11 @@ def set_ti_by_all_turbines(df):
     return _set_col_by_turbines("ti", "ti", df, "all", False)
 
 
-def set_ti_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
+def set_ti_by_upstream_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    exclude_turbs: List[int] = [],
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add TI column using upstream turbines.
 
     Add a column called 'ti' in your dataframe with value equal
@@ -651,8 +688,14 @@ def set_ti_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
 
 
 def set_ti_by_upstream_turbines_in_radius(
-    df, df_upstream, turb_no, x_turbs, y_turbs, max_radius, include_itself=True
-):
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    turb_no: int,
+    x_turbs: List[float],
+    y_turbs: List[float],
+    max_radius: float,
+    include_itself: bool = True,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add TI column by upstream turbines within a radius.
 
     Add a column called 'ti' to your dataframe, which is the
@@ -698,7 +741,9 @@ def set_ti_by_upstream_turbines_in_radius(
     )
 
 
-def set_pow_ref_by_turbines(df, turbine_numbers):
+def set_pow_ref_by_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame], turbine_numbers: List[int]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add power reference column by list of turbines.
 
     Add a column called 'pow_ref' in your dataframe with value equal
@@ -719,7 +764,11 @@ def set_pow_ref_by_turbines(df, turbine_numbers):
     return _set_col_by_turbines("pow_ref", "pow", df, turbine_numbers, False)
 
 
-def set_pow_ref_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
+def set_pow_ref_by_upstream_turbines(
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    exclude_turbs: List[int] = [],
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add pow_ref column using upstream turbines.
 
     Add a column called 'pow_ref' in your dataframe with value equal
@@ -754,8 +803,14 @@ def set_pow_ref_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
 
 
 def set_pow_ref_by_upstream_turbines_in_radius(
-    df, df_upstream, turb_no, x_turbs, y_turbs, max_radius, include_itself=False
-):
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    turb_no: int,
+    x_turbs: List[float],
+    y_turbs: List[float],
+    max_radius: float,
+    include_itself: bool = False,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add pow_ref column using upstream turbines within a radius.
 
     Add a column called 'pow_ref' to your dataframe, which is the
@@ -802,8 +857,14 @@ def set_pow_ref_by_upstream_turbines_in_radius(
 
 
 def set_pow_ref_by_n_closest_upstream_turbines(
-    df, df_upstream, turb_no, x_turbs, y_turbs, exclude_turbs=[], N=5
-):
+    df: Union[pd.DataFrame, FlascDataFrame],
+    df_upstream: pd.DataFrame,
+    turb_no: int,
+    x_turbs: List[float],
+    y_turbs: List[float],
+    exclude_turbs: bool = [],
+    N: int = 5,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Add pow_ref column using N-nearest upstream turbines.
 
     Add a column called 'pow_ref' to your dataframe, which is the
@@ -846,7 +907,11 @@ def set_pow_ref_by_n_closest_upstream_turbines(
     )
 
 
-def df_reduce_precision(df_in, verbose=False, allow_convert_to_integer=True):
+def df_reduce_precision(
+    df_in: Union[pd.DataFrame, FlascDataFrame],
+    verbose: bool = False,
+    allow_convert_to_integer: bool = True,
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Reduce dataframe precision.
 
     Reduce the precision in dataframes from float64 to float32, or possibly
@@ -922,7 +987,9 @@ def df_reduce_precision(df_in, verbose=False, allow_convert_to_integer=True):
 
 
 # Functions used for dataframe processing specifically
-def df_drop_nan_rows(df, verbose=False):
+def df_drop_nan_rows(
+    df: Union[pd.DataFrame, FlascDataFrame], verbose: bool = False
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Drop all-nan rows.
 
     Remove entries in dataframe where all rows (besides 'time')
@@ -945,7 +1012,9 @@ def df_drop_nan_rows(df, verbose=False):
     return df
 
 
-def df_find_and_fill_data_gaps_with_missing(df, missing_data_buffer=5.0):
+def df_find_and_fill_data_gaps_with_missing(
+    df: Union[pd.DataFrame, FlascDataFrame], missing_data_buffer: float = 5.0
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Find and fill data gap and mark as missing data with NaN.
 
     This function takes a pd.DataFrame object and look for large jumps in
@@ -958,7 +1027,7 @@ def df_find_and_fill_data_gaps_with_missing(df, missing_data_buffer=5.0):
 
     Args:
         df (pd.Dataframe | FlascDataFrame): Merged dataframe for all imported files
-        missing_data_buffer (int, optional): If the time gaps are equal or
+        missing_data_buffer (float, optional): If the time gaps are equal or
             larger than this limit [s], then it will consider the data as
             corrupted or missing. Defaults to 10.
 
@@ -1016,7 +1085,7 @@ def df_find_and_fill_data_gaps_with_missing(df, missing_data_buffer=5.0):
     return df
 
 
-def df_sort_and_find_duplicates(df):
+def df_sort_and_find_duplicates(df: Union[pd.DataFrame, FlascDataFrame]):
     """This function sorts the dataframe and finds rows with equal time index.
 
     Args:
@@ -1039,14 +1108,14 @@ def df_sort_and_find_duplicates(df):
 
 
 def is_day_or_night(
-    df: pd.DataFrame,
+    df: Union[pd.DataFrame, FlascDataFrame],
     latitude: float,
     longitude: float,
     sunrise_altitude: float = 0,
     sunset_altitude: float = 0,
     lag_hours: float = 0,
     datetime_column: str = "time",
-):
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Determine night or day in dataframe.
 
     Determine whether it's day or night for a given set of coordinates and
@@ -1106,7 +1175,9 @@ def is_day_or_night(
     return df
 
 
-def plot_sun_altitude_with_day_night_color(df: pd.DataFrame, ax: plt.axis = None):
+def plot_sun_altitude_with_day_night_color(
+    df: Union[pd.DataFrame, FlascDataFrame], ax: plt.axis = None
+) -> plt.axis:
     """Plot sun altitude with day-night color differentiation.
 
     This function creates a plot of Sun Altitude over time,
@@ -1170,7 +1241,9 @@ def plot_sun_altitude_with_day_night_color(df: pd.DataFrame, ax: plt.axis = None
     return ax
 
 
-def df_sort_and_fix_duplicates(df):
+def df_sort_and_fix_duplicates(
+    df: Union[pd.DataFrame, FlascDataFrame],
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Sort dataframe and fill duplicates.
 
     This function sorts the dataframe and addresses duplicate rows (i.e.,

--- a/flasc/data_processing/dataframe_manipulations.py
+++ b/flasc/data_processing/dataframe_manipulations.py
@@ -1,5 +1,7 @@
 """Module containing methods for FLASC dataframe manipulations."""
 
+from __future__ import annotations
+
 import datetime
 import os as os
 import warnings

--- a/flasc/data_processing/dataframe_manipulations.py
+++ b/flasc/data_processing/dataframe_manipulations.py
@@ -3,6 +3,7 @@
 import datetime
 import os as os
 import warnings
+from typing import List
 from xmlrpc.client import Boolean
 
 import matplotlib.pyplot as plt
@@ -10,6 +11,7 @@ import numpy as np
 import pandas as pd
 from floris.utilities import wrap_360
 
+from flasc.flasc_dataframe import FlascDataFrame
 from flasc.logging_manager import LoggingManager
 from flasc.utilities import floris_tools as ftools, utilities as fsut
 
@@ -18,30 +20,34 @@ logger = logger_manager.logger  # Obtain the reusable logger
 
 
 # Functions related to wind farm analysis for df
-def filter_df_by_ws(df, ws_range):
+def filter_df_by_ws(
+    df: pd.DataFrame | FlascDataFrame, ws_range: List[float, float]
+) -> pd.DataFrame | FlascDataFrame:
     """Filter a dataframe by wind speed range.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements.
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements.
         ws_range ([float, float]): Wind speed range [lower bound, upper bound].
 
     Returns:
-        pd.DataFrame: Filtered dataframe.
+        pd.DataFrame | FlascDataFrame: Filtered dataframe.
     """
     df = df[df["ws"] >= ws_range[0]]
     df = df[df["ws"] < ws_range[1]]
     return df
 
 
-def filter_df_by_wd(df, wd_range):
+def filter_df_by_wd(
+    df: pd.DataFrame | FlascDataFrame, wd_range: List[float, float]
+) -> pd.DataFrame | FlascDataFrame:
     """Filter a dataframe by wind direction range.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements.
+        df (pd.DataFrame | FlascDataframe): Dataframe with measurements.
         wd_range ([float, float]): Wind direction range [lower bound, upper bound].
 
     Returns:
-        pd.DataFrame: Filtered dataframe.
+        pd.DataFrame | FlascDataFrame: Filtered dataframe.
     """
     lb = wd_range[0]
     ub = wd_range[1]
@@ -58,11 +64,13 @@ def filter_df_by_wd(df, wd_range):
     return df
 
 
-def filter_df_by_ti(df, ti_range):
+def filter_df_by_ti(
+    df: pd.DataFrame | FlascDataFrame, ti_range: List[float, float]
+) -> pd.DataFrame | FlascDataFrame:
     """Filter a dataframe by turbulence intensity range.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements.
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements.
         ti_range ([float, float]): Turbulence intensity range [lower bound, upper bound].
 
     Returns:
@@ -77,7 +85,7 @@ def get_num_turbines(df):
     """Get the number of turbines in a dataframe.
 
     Args:
-        df (pd.DataFrame): Dataframe with turbine data
+        df (pd.DataFrame | FlascDataFrame): Dataframe with turbine data
 
     Returns:
          int: Number of turbines in the dataframe
@@ -90,7 +98,7 @@ def get_column_mean(df, col_prefix="pow", turbine_list=None, circular_mean=False
     """Get the mean of a column for a list of turbines.
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements.
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements.
         col_prefix (str, optional): Column prefix to use. Defaults to "pow".
         turbine_list ([list, array], optional): List of turbine numbers to use.
             If None, all turbines are used.  Defaults to None.
@@ -319,14 +327,14 @@ def set_wd_by_turbines(df, turbine_numbers):
     the turbines in turbine_numbers.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         turbine_numbers ([list, array]): List of turbine numbers that
             should be used to calculate the column average.
 
     Returns:
-        df (pd.DataFrame): Dataframe which equals the inserted dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe which equals the inserted dataframe
             plus the additional column called 'wd'.
     """
     return _set_col_by_turbines("wd", "wd", df, turbine_numbers, True)
@@ -340,12 +348,12 @@ def set_wd_by_all_turbines(df):
     turbines.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'wd'.
     """
     return _set_col_by_turbines("wd", "wd", df, "all", True)
@@ -359,7 +367,7 @@ def set_wd_by_radius_from_turbine(df, turb_no, x_turbs, y_turbs, max_radius, inc
     [max_radius] of the turbine of interest [turb_no].
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         turb_no (int): Turbine number from which the radius should be calculated.
@@ -373,7 +381,7 @@ def set_wd_by_radius_from_turbine(df, turb_no, x_turbs, y_turbs, max_radius, inc
             to False.
 
     Returns:
-        pd.DataFrame: Dataframe which equals the inserted dataframe
+        pd.DataFrame | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'wd'.
     """
     return _set_col_by_radius_from_turbine(
@@ -397,14 +405,14 @@ def set_ws_by_turbines(df, turbine_numbers):
     turbine_numbers.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
         typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
         potentially additional measurements.
         turbine_numbers ([list, array]): List of turbine numbers that
         should be used to calculate the column average.
 
     Returns:
-        df (pd.DataFrame): Dataframe which equals the inserted dataframe
+        pd.DataFrame | FlascDataFrame: Dataframe which equals the inserted dataframe
         plus the additional column called 'ws'.
     """
     return _set_col_by_turbines("ws", "ws", df, turbine_numbers, False)
@@ -418,14 +426,14 @@ def set_ws_by_all_turbines(df):
     turbines.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         turbine_numbers ([list, array]): List of turbine numbers that
             should be used to calculate the column average.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'ws'.
     """
     return _set_col_by_turbines("ws", "ws", df, "all", False)
@@ -439,7 +447,7 @@ def set_ws_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
     upstream, excluding the turbines listed in exclude_turbs.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.DataFrame): Dataframe containing rows indicating
@@ -454,7 +462,7 @@ def set_ws_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
             mean quantity.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'ws'.
     """
     return _set_col_by_upstream_turbines(
@@ -478,7 +486,7 @@ def set_ws_by_upstream_turbines_in_radius(
     [turb_no].
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.DataFrame): Dataframe containing rows indicating
@@ -498,7 +506,7 @@ def set_ws_by_upstream_turbines_in_radius(
             to False.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
         plus the additional column called 'ws'.
     """
     return _set_col_by_upstream_turbines_in_radius(
@@ -525,7 +533,7 @@ def set_ws_by_n_closest_upstream_turbines(
     upstream of the turbine of interest [turb_no].
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.DataFrame): Dataframe containing rows indicating
@@ -542,7 +550,7 @@ def set_ws_by_n_closest_upstream_turbines(
             mean quantity.
         N (int): Number of closest turbines to consider for the calculation
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
         plus the additional column called 'pow_ref'.
     """
     return _set_col_by_n_closest_upstream_turbines(
@@ -567,14 +575,14 @@ def set_ti_by_turbines(df, turbine_numbers):
     turbines listed in turbine_numbers.
 
     Args:
-        df (pd.DataFrame): Dataframe with measurements. This dataframe
+        df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         turbine_numbers ([list, array]): List of turbine numbers that
             should be used to calculate the column average.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'ti'.
     """
     return _set_col_by_turbines("ti", "ti", df, turbine_numbers, False)
@@ -588,14 +596,14 @@ def set_ti_by_all_turbines(df):
     turbines.
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         turbine_numbers ([list, array]): List of turbine numbers that
             should be used to calculate the column average.
 
     Returns:
-        df (pd.Dataframe): Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
         plus the additional column called 'ti'.
     """
     return _set_col_by_turbines("ti", "ti", df, "all", False)
@@ -609,7 +617,7 @@ def set_ti_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
     upstream, excluding the turbines listed in exclude_turbs.
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.Dataframe): Dataframe containing rows indicating
@@ -624,7 +632,7 @@ def set_ti_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
             mean quantity.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'ti'.
     """
     return _set_col_by_upstream_turbines(
@@ -648,7 +656,7 @@ def set_ti_by_upstream_turbines_in_radius(
     [turb_no].
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.Dataframe): Dataframe containing rows indicating
@@ -668,7 +676,7 @@ def set_ti_by_upstream_turbines_in_radius(
             to False.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
         plus the additional column called 'ti'.
     """
     return _set_col_by_upstream_turbines_in_radius(
@@ -693,14 +701,14 @@ def set_pow_ref_by_turbines(df, turbine_numbers):
     turbines listed in turbine_numbers.
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         turbine_numbers ([list, array]): List of turbine numbers that
             should be used to calculate the column average.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'ti'.
     """
     return _set_col_by_turbines("pow_ref", "pow", df, turbine_numbers, False)
@@ -714,7 +722,7 @@ def set_pow_ref_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
     excluding the turbines listed in exclude_turbs.
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.Dataframe): Dataframe containing rows indicating
@@ -727,7 +735,7 @@ def set_pow_ref_by_upstream_turbines(df, df_upstream, exclude_turbs=[]):
 
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'pow_ref'.
     """
     return _set_col_by_upstream_turbines(
@@ -751,7 +759,7 @@ def set_pow_ref_by_upstream_turbines_in_radius(
     [turb_no].
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.Dataframe): Dataframe containing rows indicating
@@ -771,7 +779,7 @@ def set_pow_ref_by_upstream_turbines_in_radius(
             to False.
 
     Returns:
-        pd.Dataframe Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'pow_ref'.
     """
     return _set_col_by_upstream_turbines_in_radius(
@@ -798,7 +806,7 @@ def set_pow_ref_by_n_closest_upstream_turbines(
     upstream of the turbine of interest [turb_no].
 
     Args:
-        df (pd.Dataframe): Dataframe with measurements. This dataframe
+        df (pd.Dataframe | FlascDataFrame): Dataframe with measurements. This dataframe
             typically consists of wd_%03d, ws_%03d, ti_%03d, pow_%03d, and
             potentially additional measurements.
         df_upstream (pd.Dataframe): Dataframe containing rows indicating
@@ -816,7 +824,7 @@ def set_pow_ref_by_n_closest_upstream_turbines(
             of the averaged column quantity.  Defaults to 5.
 
     Returns:
-        pd.Dataframe: Dataframe which equals the inserted dataframe
+        pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'pow_ref'.
     """
     return _set_col_by_n_closest_upstream_turbines(
@@ -844,13 +852,13 @@ def df_reduce_precision(df_in, verbose=False, allow_convert_to_integer=True):
     these variables.
 
     Args:
-        df_in (pd.Dataframe): Dataframe that needs to be reduced.
+        df_in (pd.Dataframe | FlascDataFrame): Dataframe that needs to be reduced.
         verbose (bool, optional): Print progress. Defaults to False.
         allow_convert_to_integer (bool, optional): Allow reduction to integer
            type if possible. Defaults to True.
 
     Returns:
-       pd.Dataframe: Reduced dataframe
+       pd.Dataframe | FlascDataFrame: Reduced dataframe
     """
     list_out = []
     dtypes = df_in.dtypes
@@ -916,11 +924,11 @@ def df_drop_nan_rows(df, verbose=False):
     have nan values.
 
     Args:
-        df (pd.Dataframe): Input pandas dataframe
+        df (pd.Dataframe | FlascDataFrame): Input pandas dataframe
         verbose (bool, optional): Print progress. Defaults to False.
 
     Returns:
-        pd.Dataframe: Dataframe with all-nan rows removed
+        pd.Dataframe | FlascDataFrame: Dataframe with all-nan rows removed
     """
     N_init = df.shape[0]
     colnames = [c for c in df.columns if c not in ["time", "turbid", "index"]]
@@ -944,13 +952,13 @@ def df_find_and_fill_data_gaps_with_missing(df, missing_data_buffer=5.0):
        will be ignored in any further analysis.
 
     Args:
-        df (pd.Dataframe): Merged dataframe for all imported files
+        df (pd.Dataframe | FlascDataFrame): Merged dataframe for all imported files
         missing_data_buffer (int, optional): If the time gaps are equal or
             larger than this limit [s], then it will consider the data as
             corrupted or missing. Defaults to 10.
 
     Returns:
-        pd.Dataframe: The postprocessed dataframe where all data
+        pd.Dataframe | FlascDataFrame: The postprocessed dataframe where all data
             within large time gaps hold value 'missing'.
     """
     df = df.sort_values(by="time")
@@ -1007,10 +1015,10 @@ def df_sort_and_find_duplicates(df):
     """This function sorts the dataframe and finds rows with equal time index.
 
     Args:
-        df (pd.Dataframe): An (unsorted) dataframe
+        df (pd.Dataframe | FlascDataFrame): An (unsorted) dataframe
 
     Returns:
-        pd.Dataframe: Dataframe sorted by time
+        pd.Dataframe | FlascDataFrame: Dataframe sorted by time
         duplicate_entries_idx ([list of int]): list with indices of the former
             of two duplicate rows. The indices correspond to the time-sorted df.
     """
@@ -1040,7 +1048,8 @@ def is_day_or_night(
     UTC timestamp in a DataFrame.
 
     Args:
-        df (pd.DataFrame): A Pandas DataFrame containing the time in UTC and other relevant data.
+        df (pd.DataFrame | FlascDataFrame): A Pandas DataFrame containing the time in UTC
+            and other relevant data.
         latitude (float): The latitude of the location for which to determine day or night.
         longitude (float): The longitude of the location for which to determine day or night.
         sunrise_altitude (float): The altitude of the sun to denote
@@ -1054,7 +1063,8 @@ def is_day_or_night(
             the timestamp in UTC. Default is 'time'.
 
     Returns:
-        pd.DataFrame: The input DataFrame with two additional columns: 'sun_altitude'
+        pd.DataFrame | FlascDataFrame: The input DataFrame with two additional
+            columns: 'sun_altitude'
             (the sun's altitude at the given timestamp)
             and 'is_day' (a boolean indicating whether it's daytime at the given timestamp).
 
@@ -1101,7 +1111,8 @@ def plot_sun_altitude_with_day_night_color(df: pd.DataFrame, ax: plt.axis = None
     as well as a boolean 'is_day' column to indicate day and night periods.
 
     Args:
-        df (pd.DataFrame): A DataFrame containing time, sun_altitude, and is_day columns.
+        df (pd.DataFrame | FlascDataFrame): A DataFrame containing time, sun_altitude,
+            and is_day columns.
         ax (plt.axis, optional): An optional Matplotlib axis to use for the plot.
             If not provided, a new axis will be created.
 
@@ -1154,20 +1165,6 @@ def plot_sun_altitude_with_day_night_color(df: pd.DataFrame, ax: plt.axis = None
     return ax
 
 
-# TODO: This function is not referenced and doesn't connect to current code really?
-# Going to comment out rather than add docstring
-# def make_df_wide(df):
-#     df["turbid"] = df["turbid"].astype(int)
-#     df = df.reset_index(drop=False)
-#     if "index" in df.columns:
-#         df = df.drop(columns="index")
-#     df = df.set_index(["time", "turbid"], drop=True)
-#     df = df.unstack()
-#     df.columns = ["%s_%s" % c for c in df.columns]
-#     df = df.reset_index(drop=False)
-#     return df
-
-
 def df_sort_and_fix_duplicates(df):
     """Sort dataframe and fill duplicates.
 
@@ -1178,10 +1175,10 @@ def df_sort_and_fix_duplicates(df):
     column, then an exception is thrown.
 
     Args:
-        df (pd.Dataframe): An (unsorted) dataframe
+        df (pd.Dataframe | FlascDataFrame): An (unsorted) dataframe
 
     Returns:
-        df (pd.Dataframe): A time-sorted Dataframe in which its duplicate
+        df (pd.Dataframe | FlascDataFrame): A time-sorted Dataframe in which its duplicate
         rows have been merged.
     """
     # Check and merge any duplicate entries in the dataset

--- a/flasc/data_processing/dataframe_manipulations.py
+++ b/flasc/data_processing/dataframe_manipulations.py
@@ -3,7 +3,7 @@
 import datetime
 import os as os
 import warnings
-from typing import List
+from typing import List, Optional, Union
 from xmlrpc.client import Boolean
 
 import matplotlib.pyplot as plt
@@ -21,8 +21,8 @@ logger = logger_manager.logger  # Obtain the reusable logger
 
 # Functions related to wind farm analysis for df
 def filter_df_by_ws(
-    df: pd.DataFrame | FlascDataFrame, ws_range: List[float, float]
-) -> pd.DataFrame | FlascDataFrame:
+    df: Union[pd.DataFrame, FlascDataFrame], ws_range: List[float]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Filter a dataframe by wind speed range.
 
     Args:
@@ -38,8 +38,8 @@ def filter_df_by_ws(
 
 
 def filter_df_by_wd(
-    df: pd.DataFrame | FlascDataFrame, wd_range: List[float, float]
-) -> pd.DataFrame | FlascDataFrame:
+    df: Union[pd.DataFrame, FlascDataFrame], wd_range: List[float]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Filter a dataframe by wind direction range.
 
     Args:
@@ -65,8 +65,8 @@ def filter_df_by_wd(
 
 
 def filter_df_by_ti(
-    df: pd.DataFrame | FlascDataFrame, ti_range: List[float, float]
-) -> pd.DataFrame | FlascDataFrame:
+    df: Union[pd.DataFrame, FlascDataFrame], ti_range: List[float]
+) -> Union[pd.DataFrame, FlascDataFrame]:
     """Filter a dataframe by turbulence intensity range.
 
     Args:
@@ -81,7 +81,7 @@ def filter_df_by_ti(
     return df
 
 
-def get_num_turbines(df):
+def get_num_turbines(df: Union[pd.DataFrame, FlascDataFrame]) -> int:
     """Get the number of turbines in a dataframe.
 
     Args:
@@ -94,7 +94,12 @@ def get_num_turbines(df):
 
 
 # Generic functions for column operations
-def get_column_mean(df, col_prefix="pow", turbine_list=None, circular_mean=False):
+def get_column_mean(
+    df: Union[pd.DataFrame, FlascDataFrame],
+    col_prefix: str = "pow",
+    turbine_list: Optional[Union[List[int], np.ndarray]] = None,
+    circular_mean: bool = False,
+) -> np.ndarray:
     """Get the mean of a column for a list of turbines.
 
     Args:

--- a/flasc/data_processing/energy_ratio_wd_bias_estimation.py
+++ b/flasc/data_processing/energy_ratio_wd_bias_estimation.py
@@ -1,5 +1,7 @@
 """Module to estimate the wind direction bias."""
 
+from __future__ import annotations
+
 import os as os
 from typing import Callable, List, Union
 

--- a/flasc/data_processing/energy_ratio_wd_bias_estimation.py
+++ b/flasc/data_processing/energy_ratio_wd_bias_estimation.py
@@ -1,7 +1,7 @@
 """Module to estimate the wind direction bias."""
 
 import os as os
-from typing import Callable, List
+from typing import Callable, List, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,6 +12,7 @@ from scipy import optimize as opt, stats as spst
 from flasc.analysis import energy_ratio as er
 from flasc.analysis.energy_ratio_input import EnergyRatioInput
 from flasc.data_processing import dataframe_manipulations as dfm
+from flasc.flasc_dataframe import FlascDataFrame
 from flasc.logging_manager import LoggingManager
 from flasc.utilities import floris_tools as ftools
 
@@ -33,7 +34,7 @@ class bias_estimation(LoggingManager):
 
     def __init__(
         self,
-        df: pd.DataFrame,
+        df: Union[pd.DataFrame, FlascDataFrame],
         df_fm_approx: pd.DataFrame,
         test_turbines_subset: List[int],
         df_ws_mapping_func: Callable,
@@ -42,7 +43,7 @@ class bias_estimation(LoggingManager):
         """Initialize the bias estimation class.
 
         Args:
-            df (pd.Dataframe): Dataframe with the SCADA data measurements
+            df (pd.Dataframe | FlascDataFrame): Dataframe with the SCADA data measurements
                 formatted in the generic format. The dataframe should contain
                 at the minimum the following columns:
                 * Reference wind direction for the test turbine, 'wd'

--- a/flasc/data_processing/filtering.py
+++ b/flasc/data_processing/filtering.py
@@ -24,7 +24,7 @@ def df_get_no_faulty_measurements(df, turbine):
     """Get the number of faulty measurements for a specific turbine.
 
     Args:
-        df (pd.DataFrame): Dataframe containing the turbine data,
+        df (pd.DataFrame | FlascDataFrame): Dataframe containing the turbine data,
             formatted in the generic SCADA data format. Namely, the
             dataframe should at the very least contain the columns:
               * Time of each measurement: time
@@ -47,7 +47,7 @@ def df_mark_turbdata_as_faulty(df, cond, turbine_list, exclude_columns=[]):
     """Mark turbine data as faulty based on a condition.
 
     Args:
-        df (pd.DataFrame): Dataframe containing the turbine data,
+        df (pd.DataFrame | FlascDataFrame): Dataframe containing the turbine data,
             formatted in the generic SCADA data format.
         cond (iteratible): List or array-like variable with bool entries
             depicting whether the condition is met or not. These should be
@@ -60,7 +60,7 @@ def df_mark_turbdata_as_faulty(df, cond, turbine_list, exclude_columns=[]):
             be considered for the filtering. Defaults to [].
 
     Returns:
-        pd.DataFrame: Dataframe with the faulty measurements marked as None.
+        pd.DataFrame | FlascDataFrame: Dataframe with the faulty measurements marked as None.
     """
     if isinstance(turbine_list, (np.integer, int)):
         turbine_list = [turbine_list]
@@ -92,7 +92,7 @@ class FlascFilter:
         """Initializes the class.
 
         Args:
-            df (pd.DataFrame): Dataframe containing the turbine data,
+            df (pd.DataFrame | FlascDataFrame): Dataframe containing the turbine data,
                 formatted in the generic SCADA data format. Namely, the
                 dataframe should at the very least contain the columns:
                   * Time of each measurement: time
@@ -293,7 +293,8 @@ class FlascFilter:
                 self.df directly as NaN. Defaults to True.
 
         Returns:
-            pd.Dataframe: The filtered dataframe. All measurements that are flagged as faulty
+            pd.Dataframe | FlascDataFrame: The filtered dataframe.
+                All measurements that are flagged as faulty
                 are overwritten by "None"/"NaN". If apply_filters_to_df==True, then this
                 dataframe is equal to the internally filtered dataframe 'self.df'.
         """
@@ -388,7 +389,8 @@ class FlascFilter:
             verbose (bool, optional): Print information to console. Defaults to True.
 
         Returns:
-            pd.Dataframe: Pandas DataFrame with the filtered data, in which faulty turbine
+            pd.Dataframe | FlascDataFrame: Pandas DataFrame with the filtered data,
+                in which faulty turbine
                 measurements are flagged as None/NaN. This is an aggregated filtering
                 variable, so it includes faulty-flagged measurements from filter
                 operations in previous steps.
@@ -640,7 +642,8 @@ class FlascFilter:
                 value to 15.0.
 
         Returns:
-            pd.Dataframe: Pandas DataFrame with the filtered data, in which faulty turbine
+            pd.Dataframe | FlascDataFrame: Pandas DataFrame with the filtered data,
+                in which faulty turbine
                 measurements are flagged as None/NaN. This is an aggregated filtering
                 variable, so it includes faulty-flagged measurements from filter
                 operations in previous steps.
@@ -770,7 +773,8 @@ class FlascFilter:
         """Return the filtered dataframe to the user.
 
         Returns:
-            self.df: Pandas DataFrame with the filtered data, in which faulty turbine
+           pd.DataFrame | FlascDataFrame: Pandas DataFrame with the filtered data,
+                in which faulty turbine
                 measurements are flagged as None/NaN. This is an aggregated filtering
                 variable, so it includes faulty-flagged measurements from filter
                 operations in previous steps.
@@ -1291,7 +1295,7 @@ def filter_df_by_faulty_impacting_turbines(df, ti, df_impacting_turbines, verbos
       that are shedding a wake on this turbine is reporting NaN measurements.
 
     Args:
-        df (pd.DataFrame): Dataframe with SCADA data with measurements
+        df (pd.DataFrame | FlascDataFrame): Dataframe with SCADA data with measurements
             formatted according to wd_000, wd_001, wd_002, pow_000, pow_001,
             pow_002, and so on.
         ti (int): Turbine number for which we are filtering the data.

--- a/flasc/data_processing/find_sensor_faults.py
+++ b/flasc/data_processing/find_sensor_faults.py
@@ -24,7 +24,7 @@ def find_sensor_stuck_faults(
     """Find sensor-stuck faults in a dataframe.
 
     Args:
-        df (pd.DataFrame): The dataframe containing the data.
+        df (pd.DataFrame | FlascDataFrame): The dataframe containing the data.
         columns (list): The columns to check for sensor-stuck faults.
         ti (Any): unused
         stddev_threshold (float, optional): The threshold for the standard deviation of the

--- a/flasc/data_processing/northing_offset.py
+++ b/flasc/data_processing/northing_offset.py
@@ -21,7 +21,7 @@ def crosscheck_northing_offset_consistency(
     """Cross-check the consistency of the northing offset between turbines.
 
     Args:
-        df (pd.DataFrame): DataFrame containing the relevant data.
+        df (pd.DataFrame | FlascDataFrame): DataFrame containing the relevant data.
         fm (floris.simulation.Floris): Floris object.
         bias_timestep (timedelta, optional): Time step for bias calculation.
             Defaults to td(days=120).

--- a/flasc/data_processing/time_operations.py
+++ b/flasc/data_processing/time_operations.py
@@ -28,7 +28,7 @@ def df_movingaverage(
     Standard deviation handles angular quantities.
 
     Args:
-        df_in (pd.DataFrame): Input dataframe.
+        df_in (pd.DataFrame | FlascDataFrame): Input dataframe.
         cols_angular (list): List of angular columns.
         window_width (timedelta): Width of the moving average window.
         min_periods (int): Minimum number of periods to consider.
@@ -121,7 +121,7 @@ def df_downsample(
     """Downsample a dataframe to a average accounting for angular columns.
 
     Args:
-        df_in (pd.DataFrame): Input dataframe.
+        df_in (pd.DataFrame | FlascDataFrame): Input dataframe.
         cols_angular (list): List of angular columns.
         window_width (timedelta): Width of the average window.
         min_periods (int): Minimum number of data points for a bin to be valid.
@@ -134,7 +134,7 @@ def df_downsample(
         A tuple (pd.DataFrame, np.ndarray) if return_index_mapping is True.  Where
             the DataFrame is the downsampled dataframe and the np.ndarray is the
             index mapping.
-        A pd.DataFrame if return_index_mapping is False.
+        A pd.DataFrame | FlascDataFrame if return_index_mapping is False.
 
     """
     # Copy and ensure dataframe is indexed by time
@@ -345,7 +345,7 @@ def df_resample_by_interpolation(
     """Resample a dataframe by interpolation onto a new time array.
 
     Args:
-        df (pd.DataFrame): Input dataframe.
+        df (pd.DataFrame | FlascDataFrame): Input dataframe.
         time_array (np.array): New time array.
         circular_cols (list): List of columns that are circular.
         interp_method (str): Interpolation method.  Default is "linear".
@@ -354,7 +354,7 @@ def df_resample_by_interpolation(
         verbose (bool): Print information.  Default is True.
 
     Returns:
-        pd.DataFrame: Resampled dataframe
+        pd.DataFrame | FlascDataFrame: Resampled dataframe
 
     """
     # Copy with properties but no actual data
@@ -423,10 +423,10 @@ def flatten_cols(df):
     """Flatten multi-level columns in a DataFrame.
 
     Args:
-        df (pd.DataFrame): Input DataFrame.
+        df (pd.DataFrame | FlascDataFrame): Input DataFrame.
 
     Returns:
-        pd.DataFrame: Flattened DataFrame.
+        pd.DataFrame | FlascDataFrame: Flattened DataFrame.
 
     """
     cols = ["_".join(map(str, vals)) for vals in df.columns.to_flat_index()]

--- a/flasc/flasc_dataframe.py
+++ b/flasc/flasc_dataframe.py
@@ -46,10 +46,6 @@ class FlascDataFrame(DataFrame):
         """
         super().__init__(*args, **kwargs)
 
-        # Check that the time column is present
-        if "time" not in self.columns:
-            raise ValueError("Column 'time' must be present in the DataFrame")
-
         # check that name_map dictionary is valid
         if channel_name_map is not None:
             if not isinstance(channel_name_map, dict):

--- a/flasc/model_fitting/yaw_pow_fitting.py
+++ b/flasc/model_fitting/yaw_pow_fitting.py
@@ -20,7 +20,7 @@ class yaw_pow_fitting:
         """Initialize the yaw power curve fitting object.
 
         Args:
-            df (pd.DataFrame): DataFrame containing the relevant data.
+            df (pd.DataFrame | FlascDataFrame): DataFrame containing the relevant data.
             df_upstream (pd.DataFrame): DataFrame containing the upstream conditions.
             ti (int): Index of the turbine to fit the yaw power curve to.
         """
@@ -36,7 +36,7 @@ class yaw_pow_fitting:
         """Set the dataframe for the yaw power curve fitting object.
 
         Args:
-            df (pd.DataFrame): DataFrame containing the relevant data.
+            df (pd.DataFrame | FlascDataFrame): DataFrame containing the relevant data.
             df_upstream (pd.DataFrame): DataFrame containing the upstream conditions.
             ti (int): Index of the turbine to fit the yaw power curve to.
         """

--- a/flasc/utilities/energy_ratio_utilities.py
+++ b/flasc/utilities/energy_ratio_utilities.py
@@ -1,5 +1,7 @@
 """Utility functions for calculating energy ratios."""
 
+from __future__ import annotations
+
 import warnings
 from typing import List, Optional, Union
 

--- a/flasc/utilities/floris_tools.py
+++ b/flasc/utilities/floris_tools.py
@@ -42,7 +42,8 @@ def interpolate_floris_from_df_approx(
     timeseries samples.
 
     Args:
-        df (pd.DataFrame): A Pandas DataFrame containing the timeseries for
+        df (pd.DataFrame | FlascDataFrame): A Pandas DataFrame
+        containing the timeseries for
         which the FLORIS predictions should be calculated. It should contain
         at least the columns 'wd', 'ws', and 'ti', which are respectively the
         ambient wind direction, ambient wind speed, and ambient turbulence

--- a/flasc/utilities/optimization.py
+++ b/flasc/utilities/optimization.py
@@ -42,8 +42,8 @@ def find_timeshift_between_dfs(
     has been removed.
 
     Args:
-        df1 (pd.DataFrame): Dataframe 1.
-        df2 (pd.DataFrame): Dataframe 2.
+        df1 (pd.DataFrame | FlascDataFrame): Dataframe 1.
+        df2 (pd.DataFrame | FlascDataFrame): Dataframe 2.
         cols_df1 (list): Columns to use in dataframe 1.
         cols_df2 (list): Columns to use in dataframe 2.
         use_circular_statistics (bool): Use circular statistics for averaging.

--- a/flasc/utilities/tuner_utilities.py
+++ b/flasc/utilities/tuner_utilities.py
@@ -6,6 +6,8 @@ parameters in a FLORIS model.
 
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/flasc/utilities/tuner_utilities.py
+++ b/flasc/utilities/tuner_utilities.py
@@ -6,19 +6,22 @@ parameters in a FLORIS model.
 
 """
 
-
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
 from floris import FlorisModel
 
 from flasc.data_processing import dataframe_manipulations as dfm
+from flasc.flasc_dataframe import FlascDataFrame
 from flasc.utilities.utilities_examples import load_floris_smarteole
 
 
-def replicate_nan_values(df_1: pd.DataFrame, df_2: pd.DataFrame):
+def replicate_nan_values(
+    df_1: Union[pd.DataFrame, FlascDataFrame],
+    df_2: Union[pd.DataFrame, FlascDataFrame],
+):
     """Replicate NaN Values in DataFrame df_2 to Match DataFrame df_1.
 
     For columns that are common between df_1 and df_2, this function ensures that
@@ -27,8 +30,9 @@ def replicate_nan_values(df_1: pd.DataFrame, df_2: pd.DataFrame):
     df_1, and you want to ensure that missing data is consistent between the two DataFrames.
 
     Args:
-        df_1 (pandas.DataFrame): The reference DataFrame containing NaN values.
-        df_2 (pandas.DataFrame): The DataFrame to be updated to match NaN positions in df_1.
+        df_1 (pandas.DataFrame | FlascDataFrame): The reference DataFrame containing NaN values.
+        df_2 (pandas.DataFrame | FlascDataFrame): The DataFrame to be updated
+             to match NaN positions in df_1.
 
     Returns:
         pandas.DataFrame: A new DataFrame with NaN values in df_2 replaced to match df_1.
@@ -96,7 +100,9 @@ def nested_set(dic: Dict[str, Any], keys: List[str], value: Any, idx: Optional[i
         dic[keys[-1]] = par_list
 
 
-def resim_floris(fm_in: FlorisModel, df_scada: pd.DataFrame, yaw_angles: np.array = None):
+def resim_floris(
+    fm_in: FlorisModel, df_scada: Union[pd.DataFrame, FlascDataFrame], yaw_angles: np.array = None
+):
     """Resimulate FLORIS with SCADA data.
 
     This function takes a FlorisModel  and a SCADA dataframe, and resimulates the
@@ -106,7 +112,7 @@ def resim_floris(fm_in: FlorisModel, df_scada: pd.DataFrame, yaw_angles: np.arra
 
     Args:
         fm_in (FlorisModel): The FlorisModel to resimulate.
-        df_scada (pd.DataFrame): The SCADA data to use for resimulation.
+        df_scada (pd.DataFrame | FlascDataFrame): The SCADA data to use for resimulation.
         yaw_angles (np.array, optional): The yaw angles to use for resimulation. Defaults to None.
 
     Returns:

--- a/flasc/utilities/utilities.py
+++ b/flasc/utilities/utilities.py
@@ -34,7 +34,7 @@ def get_num_turbines(df):
     """Get the number of turbines in a dataframe.
 
     Args:
-        df (pd.DataFrame): Dataframe with turbine data
+        df (pd.DataFrame | FlascDataFrame): Dataframe with turbine data
 
     Returns:
        int: Number of turbines in the dataframe

--- a/flasc/yaw_optimizer_visualization.py
+++ b/flasc/yaw_optimizer_visualization.py
@@ -23,8 +23,8 @@ def plot_uplifts_by_atmospheric_conditions(
     This function plots the relative power gains and contributions to AEP uplift
 
     Args:
-        df_list (List[pd.DataFrame]): List of dataframes with power gains and contributions
-            to AEP uplift.
+        df_list (List[pd.DataFrame | FlascDataFrame]): List of dataframes with power gains
+            and contributions to AEP uplift.
         labels (List[str]): List of labels for the dataframes. Defaults to None.
         ws_edges (np.array): Wind speed bin edges. Defaults to np.arange(3.0, 17.0, 1.0).
         wd_edges (np.array): Wind direction bin edges. Defaults to np.arange(0.0, 360.0001, 3.0).

--- a/tests/df_time_operations_test.py
+++ b/tests/df_time_operations_test.py
@@ -80,6 +80,9 @@ class TestDataFrameResampling(unittest.TestCase):
 
         self.assertAlmostEqual(df_ds.iloc[0]["ws_000_mean"], 7.10)
 
+        # Assert df_ds is a FlascDataFrame
+        self.assertTrue(isinstance(df_ds, FlascDataFrame))
+
     def test_moving_average(self):
         df = load_data()
         df_ma = df_movingaverage(
@@ -123,6 +126,9 @@ class TestDataFrameResampling(unittest.TestCase):
         # Check solutions: sixth row, for good measure
         self.assertAlmostEqual(df_ma.iloc[6]["wd_000_mean"], 0.0)  # confirm circular averaging
 
+        # Assert df_ma is a FlascDataFrame
+        self.assertTrue(isinstance(df_ma, FlascDataFrame))
+
     def test_resample_by_interpolation(self):
         # Now resample that by filling in the gaps
         df = load_data()
@@ -162,3 +168,6 @@ class TestDataFrameResampling(unittest.TestCase):
 
         # Make sure linear interpolation works correctly over gaps
         self.assertAlmostEqual(df_res.loc[68, "wd_000"], 359.9667, places=3)
+
+        # Assert df_res is a FlascDataFrame
+        self.assertTrue(isinstance(df_res, FlascDataFrame))

--- a/tests/df_time_operations_test.py
+++ b/tests/df_time_operations_test.py
@@ -9,6 +9,7 @@ from flasc.data_processing.time_operations import (
     df_movingaverage,
     df_resample_by_interpolation,
 )
+from flasc.flasc_dataframe import FlascDataFrame
 
 
 def load_data():
@@ -64,6 +65,21 @@ class TestDataFrameResampling(unittest.TestCase):
         self.assertTrue(np.all(np.unique(data_indices[-2, :]) == [-1, 6]))
         self.assertTrue(np.isnan(df_ds.iloc[-2]["vane_000_std"]))
 
+        # Check behavior works with FlascDataFrame
+        df = FlascDataFrame(load_data())
+
+        df_ds, data_indices = df_downsample(
+            df_in=df,
+            cols_angular=["wd_000"],
+            window_width=td(seconds=5),
+            min_periods=1,
+            center=True,
+            calc_median_min_max_std=True,
+            return_index_mapping=True,
+        )
+
+        self.assertAlmostEqual(df_ds.iloc[0]["ws_000_mean"], 7.10)
+
     def test_moving_average(self):
         df = load_data()
         df_ma = df_movingaverage(
@@ -93,6 +109,20 @@ class TestDataFrameResampling(unittest.TestCase):
         self.assertTrue(np.isnan(df_ma.iloc[6]["ws_000_std"]))
         self.assertTrue(np.isnan(df_ma.iloc[6]["vane_000_std"]))
 
+        # Test behavior with FlascDataFrame
+        df = FlascDataFrame(load_data())
+        df_ma = df_movingaverage(
+            df_in=df,
+            cols_angular=["wd_000"],
+            window_width=td(seconds=5),
+            min_periods=1,
+            center=True,
+            calc_median_min_max_std=True,
+        )
+
+        # Check solutions: sixth row, for good measure
+        self.assertAlmostEqual(df_ma.iloc[6]["wd_000_mean"], 0.0)  # confirm circular averaging
+
     def test_resample_by_interpolation(self):
         # Now resample that by filling in the gaps
         df = load_data()
@@ -118,3 +148,17 @@ class TestDataFrameResampling(unittest.TestCase):
         # Make sure linear interpolation works correctly over gaps
         self.assertAlmostEqual(df_res.loc[68, "wd_000"], 359.9667, places=3)
         self.assertAlmostEqual(df_res.loc[68, "vane_000"], 2.3333, places=3)
+
+        # Repeat test with FlascDataFrame
+        df = FlascDataFrame(load_data())
+        df_res = df_resample_by_interpolation(
+            df=df,
+            time_array=pd.date_range(df.iloc[0]["time"], df.iloc[-1]["time"], freq=td(seconds=1)),
+            circular_cols=["wd_000"],
+            interp_method="linear",
+            max_gap=td(seconds=5),  # Maximum gap of 5 seconds
+            verbose=False,
+        )
+
+        # Make sure linear interpolation works correctly over gaps
+        self.assertAlmostEqual(df_res.loc[68, "wd_000"], 359.9667, places=3)

--- a/tests/flasc_dataframe_test.py
+++ b/tests/flasc_dataframe_test.py
@@ -107,14 +107,6 @@ def test_printout():
     # print("\n")
 
 
-def test_time_required():
-    # Check that the time column is present
-    with pytest.raises(ValueError):
-        FlascDataFrame(
-            {"pow_000": [0, 100, 200], "ws_000": [8, 8, 8]}, channel_name_map=test_channel_name_map
-        )
-
-
 def test_check_flasc_format():
     df = FlascDataFrame(test_wide_dict, channel_name_map=test_channel_name_map)
 


### PR DESCRIPTION
# Finish FlascDataFrame

## Type Hints

This PR goes through code and updates type hints and docstrings where pd.Dataframe is called for and adds the option for FlascDataFrame to be used as well to clarify code docs.  

Note code mostly updates existing type hints, but where type hints aren't used updates docstrings.  Getting to uniform type hinting and type hinting style can be a future project

## Remove time requirement

Removes requirements time column is included, as this will necessarily be violated in certain conditions

## Add test of `FlascDataFrame` driving energy ratio

Add a test that initiating an energy ratio analysis with `FlascDataFrame` is ok

## Add test `FlascDataFrame` driving time operations

Add. to df_time_operations_test.py some additional testing ensuring matching results when using `FlascDataFrame` as input