### PR TITLE
Add observed keyword

### DIFF
--- a/flasc/data_processing/filtering.py
+++ b/flasc/data_processing/filtering.py
@@ -194,7 +194,9 @@ class FlascFilter:
         pw_curve_df_subset = (
             pd.concat(
                 [
-                    df_pow_and_ws_bins_subset.groupby(by=f"ws_{ti:03d}")[f"pow_{ti:03d}"].median()
+                    df_pow_and_ws_bins_subset.groupby(by=f"ws_{ti:03d}", observed=True)[
+                        f"pow_{ti:03d}"
+                    ].median()
                     for ti in turbine_subset
                 ],
                 axis=1,


### PR DESCRIPTION
This change adds the observed to a pandas groupby operation in filtering.py.  Since 'ws_xxx' is not a categorical this setting does nothing, but silences the present warning:

```
FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
  df_pow_and_ws_bins_subset.groupby(by=f"ws_{ti:03d}")[f"pow_{ti:03d}"].median()
```

Thinking it over, even though observed only applies to categorical values, still setting to `True` seemed more appropriate
