### PR TITLE
set observed to false

### DIFF
--- a/flasc/data_processing/filtering.py
+++ b/flasc/data_processing/filtering.py
@@ -194,7 +194,7 @@ class FlascFilter:
         pw_curve_df_subset = (
             pd.concat(
                 [
-                    df_pow_and_ws_bins_subset.groupby(by=f"ws_{ti:03d}", observed=True)[
+                    df_pow_and_ws_bins_subset.groupby(by=f"ws_{ti:03d}", observed=False)[
                         f"pow_{ti:03d}"
                     ].median()
                     for ti in turbine_subset


### PR DESCRIPTION
The previous pull request #223 assumed the observed keyword would not have an effect on the computation, and so went for the incoming pandas default value of True, based on my read of:
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html

However, this really did change the behavior, which I now understand is because of the preceding cut line:

```
        ws_bin_cuts_subset = [
            pd.cut(df[f"ws_{ti:03d}"], bins=self._pw_curve_ws_bins) for ti in turbine_subset
        ]
```
ws is a categorical in this context.   Therefore reverting back to the current default value made explicit by setting `observed=False`
