### PR TITLE
Dont replicate nans in time

### DIFF
--- a/flasc/utilities/tuner_utilities.py
+++ b/flasc/utilities/tuner_utilities.py
@@ -49,6 +49,10 @@ def replicate_nan_values(
     # Identify common columns between df_1 and df_2
     common_columns = df_1.columns.intersection(df_2.columns)
 
+    # Remove the time column from the common columns if included
+    if "time" in common_columns:
+        common_columns = common_columns.drop("time")
+
     # Use assign to create a new DataFrame with NaN values replaced
     df_2_updated = df_2.assign(
         **{col: np.where(df_1[col].isna(), np.nan, df_2[col]) for col in common_columns}

--- a/flasc/utilities/tuner_utilities.py
+++ b/flasc/utilities/tuner_utilities.py
@@ -50,8 +50,7 @@ def replicate_nan_values(
     common_columns = df_1.columns.intersection(df_2.columns)
 
     # Remove the time column from the common columns if included
-    if "time" in common_columns:
-        common_columns = common_columns.drop("time")
+    common_columns.drop("time", errors="ignore")
 
     # Use assign to create a new DataFrame with NaN values replaced
     df_2_updated = df_2.assign(


### PR DESCRIPTION
This is a very small fix to the function `replicate_nan_values` which replicates NaN values in columns that are common between two dataframes from one to another.  For some reason this does not work for the time column when it is of type `DateTime64DType`.  However, I can't think of a good reason we need to expect to replicate nans in the time column (this functionality is for marking missing turbine data).  So simply omitting this column avoids the issue. 