### PR TITLE
FLASC v2.1.1

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flasc"
-version = "2.1"
+version = "2.1.1"
 description = "FLASC provides a rich suite of analysis tools for SCADA data filtering & analysis, wind farm model validation, field experiment design, and field experiment monitoring."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
FLASC v2.1.1 patches the pypi build procedure, which was temporarily broken but undetected in v2.1

## Bug fixes
[BUGFIX] Fig pypi to not use setup.py #229 

**Full Changelog**: https://github.com/NREL/flasc/compare/v2.1...v2.1.1

NREL checklist:
- [x] Update the version in pyproject.toml
- [x] Verify that documentation is building correctly
- [ ] Create a tag in the NREL/FLASC repository (after PR is merged)