### PR TITLE
v2.1.2

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
FLASC v2.1.2 patches the pypi build procedure, adding twine install

## Bug fixes
[BUGFIX] Fig pypi to not use setup.py #231 

**Full Changelog**: https://github.com/NREL/flasc/compare/v2.1...v2.1.2

NREL checklist:
- [x] Update the version in pyproject.toml
- [x] Verify that documentation is building correctly
- [ ] Create a tag in the NREL/FLASC repository (after PR is merged)