### PR TITLE
Adding functions to set wind direction by upstream turbines

### DIFF
--- a/flasc/data_processing/dataframe_manipulations.py
+++ b/flasc/data_processing/dataframe_manipulations.py
@@ -380,7 +380,7 @@ def set_wd_by_upstream_turbines(
     upstream, excluding the turbines listed in exclude_turbs. As an
     intermediate step, the average wind direction over all turbines
     is used to determine the set of upstream turbines from which the
-    final wind direction signal is derived. 
+    final wind direction signal is derived.
 
     Args:
         df (pd.DataFrame | FlascDataFrame): Dataframe with measurements. This dataframe
@@ -401,8 +401,7 @@ def set_wd_by_upstream_turbines(
         pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
             plus the additional column called 'wd'.
     """
-
-    # First, set wind direction using all turbines 
+    # First, set wind direction using all turbines
     df = set_wd_by_all_turbines(df)
 
     # Use the farm-average wind direction to determine a new wind direction signal
@@ -419,7 +418,7 @@ def set_wd_by_upstream_turbines(
     df = df.drop(columns=["wd"])
 
     df = df.rename(columns={"wd_upstream": "wd"})
-    
+
     return df
 
 
@@ -508,10 +507,9 @@ def set_wd_by_upstream_turbines_in_radius(
         pd.Dataframe | FlascDataFrame: Dataframe which equals the inserted dataframe
         plus the additional column called 'wd'.
     """
-
-    # First, set wind direction using all turbines 
+    # First, set wind direction using all turbines
     df = set_wd_by_all_turbines(df)
-    
+
     # Use the farm-average wind direction to determine a new wind direction signal
     # using only upstream turbines within radius
     df = _set_col_by_upstream_turbines_in_radius(

--- a/tests/dataframe_manipulations_test.py
+++ b/tests/dataframe_manipulations_test.py
@@ -67,9 +67,11 @@ class TestDataframeManipulations(unittest.TestCase):
         df_test = dfm.set_wd_by_all_turbines(df_test)
         df_test = dfm.set_ws_by_upstream_turbines(df_test, df_upstream)
         df_test = dfm.set_ti_by_upstream_turbines(df_test, df_upstream)
+        df_test = dfm.set_wd_by_upstream_turbines(df_test, df_upstream)
 
         self.assertAlmostEqual(df_test.loc[0, "ws"], np.mean([5.0, 17.0]))
         self.assertAlmostEqual(df_test.loc[0, "ti"], np.mean([0.03, 0.09]))
+        self.assertAlmostEqual(df_test.loc[0, "wd"], circmean([350.0, 3.0], high=360.0))
 
     def test_set_by_upstream_turbines_in_radius(self):
         # Test set_*_by_upstream_turbines_in_radius functions
@@ -104,10 +106,20 @@ class TestDataframeManipulations(unittest.TestCase):
             max_radius=1000,
             include_itself=True,  # Include itself
         )
+        df_test = dfm.set_wd_by_upstream_turbines_in_radius(
+            df_test,
+            df_upstream,
+            turb_no=1,
+            x_turbs=np.array([0.0, 500.0, 1000.0, 1500.0]),
+            y_turbs=np.array([0.0, 500.0, 1000.0, 1500.0]),
+            max_radius=1000,
+            include_itself=False,  # Include itself
+        )
 
         self.assertAlmostEqual(df_test.loc[0, "ws"], np.mean([5.0, 17.0]))
         self.assertAlmostEqual(df_test.loc[0, "ti"], np.mean([0.09]))
         self.assertAlmostEqual(df_test.loc[0, "pow_ref"], np.mean([1500.0, 1800.0]))
+        self.assertAlmostEqual(df_test.loc[0, "wd"], circmean([350.0], high=360.0))
 
     def test_is_day_or_night(self):
         # Test is day night using noon and midnight Oct 1 2023 in London, UK


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request addresses issue #235 by adding functions `set_wd_by_upstream_turbines` and `set_wd_by_upstream_turbines_in_radius` to the `dataframe_manipulations` module. The reason for these functions is that wind directions measured by waked turbines can contain biases due to wake effects. Therefore, it could be advantageous to only use unwaked turbines to estimate the wind direction. These functions first use the average wind direction over all turbines to identify the unwaked turbines. Then the unwaked turbines (or unwaked turbines within the specified radius for `set_wd_by_upstream_turbines_in_radius `) are used to compute the final wind direction signal.

**Related issue, if one exists**
This PR closes issue #235 

**Impacted areas of the software**
The `dataframe_manipulations` module

**Test results, if applicable**
Tests added in "dataframe_manipulations_test.py"

<!-- Release checklist:
- Update the version in
    - [ ] pyproject.toml
- [ ] Create a tag in the NREL/FLASC repository
-->
