### PR TITLE
Change how number of turbines is counted

### DIFF
--- a/flasc/flasc_dataframe.py
+++ b/flasc/flasc_dataframe.py
@@ -102,10 +102,8 @@ class FlascDataFrame(DataFrame):
         """Return the number of turbines in the dataset."""
         self.check_flasc_format()
 
-        nt = 0
-        while ("pow_%03d" % nt) in self.columns:
-            nt += 1
-        return nt
+        # Count how many columns in df_columns are of the form 'pow_###'
+        return sum(len(c) == 7 and c[:4] == "pow_" and c[4:].isdigit() for c in self.columns)
 
     def check_flasc_format(self):
         """Raise an error if the data is not in FLASC format."""

--- a/flasc/utilities/utilities.py
+++ b/flasc/utilities/utilities.py
@@ -39,10 +39,8 @@ def get_num_turbines(df):
     Returns:
        int: Number of turbines in the dataframe
     """
-    nt = 0
-    while ("pow_%03d" % nt) in df.columns:
-        nt += 1
-    return nt
+    # Count how many columns in df_columns are of the form 'pow_###'
+    return sum(len(c) == 7 and c[:4] == "pow_" and c[4:].isdigit() for c in df.columns)
 
 
 def interp_with_max_gap(x, xp, fp, max_gap, kind, wrap_around_360=False):

--- a/tests/flasc_dataframe_test.py
+++ b/tests/flasc_dataframe_test.py
@@ -346,6 +346,12 @@ def test_n_turbines():
     with pytest.raises(ValueError):
         df.n_turbines
 
+    # For backwards compatibility, check that get_num_turbines in utilities returns the same result
+    from flasc.utilities.utilities import get_num_turbines
+
+    df = FlascDataFrame(test_wide_dict, channel_name_map=test_channel_name_map)
+    assert get_num_turbines(df) == 2
+
 
 def test_export_to_windup_format():
     example_data = [1.1, 2.1, 3.1]


### PR DESCRIPTION
# Change how number of turbines is counted
The current method for counting the number of turbines uses a loop to see when the next turbine doesn't appear.  This created an issue for a current project, where simply counting the number of columns that fit the pattern "pow_###" should provide the equivalent result and avoid the issue.  This PR makes the change and adds a missing back test of the older `get_num_turbines` function.
