### PR TITLE
FLASC v2.2.1

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,8 +23,8 @@ jobs:
         pip install build twine
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python -m build
         twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flasc"
-version = "2.2"
+version = "2.2.1"
 description = "FLASC provides a rich suite of analysis tools for SCADA data filtering & analysis, wind farm model validation, field experiment design, and field experiment monitoring."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
FLASC v2.2.1 patches the pypi build procedure, switching from passwords to token per (https://pypi.org/help/#apitoken)



NREL checklist:
- [x] Update the version in pyproject.toml
- [x] Verify that documentation is building correctly
- [ ] Create a tag in the NREL/FLASC repository (after PR is merged)