### PR TITLE
Add WETO stack blurb to readme, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ For technical questions or concerns, please email paul.fleming@nrel.gov.
 
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
+
+## Part of the WETO Stack
+
+FLASC is primarily developed with the support of the U.S. Department of Energy and is part of the [WETO Software Stack](https://nrel.github.io/WETOStack). For more information and other integrated modeling software, see:
+- [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)
+- [Entry Guide](https://nrel.github.io/WETOStack/_static/entry_guide/index.html)
+- [Controls and Analysis Workshop](https://nrel.github.io/WETOStack/workshops/user_workshops_2024.html#wind-farm-controls-and-analysis)
+
+
 ## Installation
 
 We recommend installing this repository in a separate virtual environment.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For technical questions or concerns, please email paul.fleming@nrel.gov.
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 
-## Part of the WETO Stack
+## WETO software
 
 FLASC is primarily developed with the support of the U.S. Department of Energy and is part of the [WETO Software Stack](https://nrel.github.io/WETOStack). For more information and other integrated modeling software, see:
 - [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,3 +20,10 @@ calibrations, and for model parameter estimation.
 
 The FLASC repository is intended as a community driven toolbox, available on
 its [GitHub Repository](https://github.com/NREL/flasc).
+
+### WETO software
+
+FLASC is primarily developed with the support of the U.S. Department of Energy and is part of the [WETO Software Stack](https://nrel.github.io/WETOStack). For more information and other integrated modeling software, see:
+- [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)
+- [Entry Guide](https://nrel.github.io/WETOStack/_static/entry_guide/index.html)
+- [Controls and Analysis Workshop](https://nrel.github.io/WETOStack/workshops/user_workshops_2024.html#wind-farm-controls-and-analysis)


### PR DESCRIPTION
Adds information about the WETO software stack to the FLASC README.md and docs landing page.
