### PR TITLE
[BUGFIX] Correct hardcoding of uplift pair name in `ExpectedPowerAnalysisOutput`

### DIFF
--- a/flasc/analysis/expected_power_analysis_output.py
+++ b/flasc/analysis/expected_power_analysis_output.py
@@ -63,12 +63,20 @@ class ExpectedPowerAnalysisOutput:
         self.cov_terms = cov_terms
 
     def _return_uplift_string(self):
-        return (
-            f"{self.uplift_results['scada_uplift']['energy_uplift_ctr_pc']:+0.2f}%, ("
-            f"{self.uplift_results['scada_uplift']['energy_uplift_lb_pc']:+0.2f}% - "
-            f"{self.uplift_results['scada_uplift']['energy_uplift_ub_pc']:+0.2f}%)"
-            f" -- N={self.uplift_results['scada_uplift']['count']}"
-        )
+        return_string = ""
+
+        for un in self.uplift_names:
+            uplift_string = (
+                f"{un}: "
+                f"{self.uplift_results[un]['energy_uplift_ctr_pc']:+0.2f}%, ("
+                f"{self.uplift_results[un]['energy_uplift_lb_pc']:+0.2f}% - "
+                f"{self.uplift_results[un]['energy_uplift_ub_pc']:+0.2f}%)"
+                f" -- N={self.uplift_results[un]['count']}"
+                "\n"
+            )
+            return_string += uplift_string
+
+        return return_string
 
     def print_uplift(self):
         """Print the uplift results."""


### PR DESCRIPTION
As raised in #250 , there appears to be a bug in the return printout of `ExpectedPowerAnalysisOutput` where the `uplift_names` is assumed to be a single element list `["scada_uplift"]`. This likely crept in in #236 because the examples simply use the name `"scada_uplift"`.

This PR alters the returned printout to use the user-specified values in `uplift_names`. It also allows multiple pairs to be defined, in case there is more than one uplift analysis to run.

The original issue can be recreated by running examples_smarteole/10_uplift_with_expected_power.ipynb but with the following cell (the second-to-last code cell)
```python
epao_standard_zero = total_uplift_expected_power(
    a_in=a_in,
    uplift_pairs=[("Baseline", "Controlled")],
    uplift_names=["scada_uplift"],
    test_turbines=[4, 5],
    use_predefined_wd=True,
    use_predefined_ws=True,
    wd_step=2.0,
    ws_min=0.25,
    ws_step=0.5,
    use_standard_error=True,
    cov_terms="zero",
    remove_any_null_turbine_bins=False,
)
epao_standard_zero.print_uplift()
```
changed to
```python
epao_standard_zero = total_uplift_expected_power(
    a_in=a_in,
    uplift_pairs=[("Baseline", "Controlled")],
    uplift_names=["different_name"], # Name doesn't match hardcoded name; causes error
    test_turbines=[4, 5],
    use_predefined_wd=True,
    use_predefined_ws=True,
    wd_step=2.0,
    ws_min=0.25,
    ws_step=0.5,
    use_standard_error=True,
    cov_terms="zero",
    remove_any_null_turbine_bins=False,
)
epao_standard_zero.print_uplift()
```

This PR allows the code to be run. Moreover, we can now also run the following, with more than one uplift pair to report on:
```python
epao_standard_zero = total_uplift_expected_power(
    a_in=a_in,
    uplift_pairs=[("Baseline", "Controlled"), ("Controlled", "Baseline")], # another pair
    uplift_names=["different_name", "inverted_data"], # Different name for each pair
    test_turbines=[4, 5],
    use_predefined_wd=True,
    use_predefined_ws=True,
    wd_step=2.0,
    ws_min=0.25,
    ws_step=0.5,
    use_standard_error=True,
    cov_terms="zero",
    remove_any_null_turbine_bins=False,
)
epao_standard_zero.print_uplift()
```

No changes to tests; all tests pass.