### PR TITLE
Update numpy, polars, and floris usage to avoid deprecation warnings

### DIFF
--- a/flasc/analysis/energy_ratio.py
+++ b/flasc/analysis/energy_ratio.py
@@ -137,7 +137,7 @@ def _compute_energy_ratio_single(
         .with_columns(energy_ratio=pl.col("test_energy") / pl.col("ref_energy"))
         .pivot(
             values=["energy_ratio", "count"],
-            columns="df_name",
+            on="df_name",
             index="wd_bin",
             aggregate_function="first",
         )

--- a/flasc/analysis/total_uplift_power_ratio.py
+++ b/flasc/analysis/total_uplift_power_ratio.py
@@ -137,7 +137,7 @@ def _total_uplift_power_ratio_single(
             )
             .pivot(
                 values=["power_ratio"],
-                columns="df_name",
+                on="df_name",
                 index=bin_cols_without_df_name + ["weight", "weighted_pow_ref"],
                 aggregate_function="first",
             )

--- a/flasc/data_processing/energy_ratio_wd_bias_estimation.py
+++ b/flasc/data_processing/energy_ratio_wd_bias_estimation.py
@@ -89,7 +89,7 @@ class bias_estimation(LoggingManager):
 
     def _load_a_input_for_wd_bias(
         self,
-        wd_bias,
+        wd_bias: float,
     ):
         """Load AnalysisInput objects with bias.
 
@@ -158,7 +158,7 @@ class bias_estimation(LoggingManager):
 
     def _get_energy_ratios_allbins(
         self,
-        wd_bias,
+        wd_bias: float,
         time_mask=None,
         ws_mask=(6.0, 10.0),
         wd_mask=None,
@@ -233,7 +233,7 @@ class bias_estimation(LoggingManager):
 
         for ii, ti in enumerate(self.test_turbines):
             self.logger.info(
-                "    Determining energy ratios for test turbine = %03d." % (ti)
+                "    Determining energy ratios for test turbine = %03d." % ti
                 + " WD bias: %.3f deg." % wd_bias
             )
 
@@ -420,9 +420,14 @@ class bias_estimation(LoggingManager):
         """
         self.logger.info("Estimating the wind direction bias")
 
-        def cost_fun(wd_bias):
+        def cost_fun(x: np.ndarray):
+            """Cost function to minimize.
+
+            Args:
+                x (np.ndarray): Wind direction bias to evaluate. 1D array with 1 element.
+            """
             self._get_energy_ratios_allbins(
-                wd_bias=wd_bias,
+                wd_bias=x[0], # pass as float
                 time_mask=time_mask,
                 ws_mask=ws_mask,
                 wd_mask=wd_mask,
@@ -467,7 +472,7 @@ class bias_estimation(LoggingManager):
             # workers=opt_workers,
         )
 
-        wd_bias = x_opt
+        wd_bias = x_opt[0]
         self.opt_wd_bias = wd_bias
         self.opt_cost = J_opt
         self.opt_wd_grid = x
@@ -476,7 +481,7 @@ class bias_estimation(LoggingManager):
         # End with optimal results and bootstrapping
         self.logger.info("  Evaluating optimal solution with bootstrapping")
         self._get_energy_ratios_allbins(
-            wd_bias=x_opt,
+            wd_bias=wd_bias,
             time_mask=time_mask,
             ws_mask=ws_mask,
             wd_mask=wd_mask,
@@ -530,7 +535,7 @@ class bias_estimation(LoggingManager):
             er_out_test_turbine_list_scada_copy = self.er_out_test_turbine_list_scada.copy()
             # (Re)compute case with wd_bias=0
             self._get_energy_ratios_allbins(
-                wd_bias=0,
+                wd_bias=0.0,
                 time_mask=self._input_args["time_mask"],
                 ws_mask=self._input_args["ws_mask"],
                 wd_mask=self._input_args["wd_mask"],

--- a/flasc/data_processing/energy_ratio_wd_bias_estimation.py
+++ b/flasc/data_processing/energy_ratio_wd_bias_estimation.py
@@ -427,7 +427,7 @@ class bias_estimation(LoggingManager):
                 x (np.ndarray): Wind direction bias to evaluate. 1D array with 1 element.
             """
             self._get_energy_ratios_allbins(
-                wd_bias=x[0], # pass as float
+                wd_bias=x[0],  # pass as float
                 time_mask=time_mask,
                 ws_mask=ws_mask,
                 wd_mask=wd_mask,

--- a/flasc/utilities/energy_ratio_utilities.py
+++ b/flasc/utilities/energy_ratio_utilities.py
@@ -577,9 +577,9 @@ def bin_and_group_dataframe(
             pl.all_horizontal(pl.col(bin_cols_with_df_name).is_not_null())
         )  # Select for all bin cols present
         .group_by(bin_cols_with_df_name, maintain_order=True)
-        .agg([pl.mean("pow_ref"), pl.mean("pow_test"), pl.count()])
+        .agg([pl.mean("pow_ref"), pl.mean("pow_test"), pl.len().alias("count")])
         # Enforce that each ws/wd bin combination has to appear in all dataframes
-        .filter(pl.count().over(bin_cols_without_df_name) == num_df)
+        .filter(pl.len().over(bin_cols_without_df_name) == num_df)
     )
 
     return df_

--- a/flasc/utilities/floris_tools.py
+++ b/flasc/utilities/floris_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 from time import perf_counter as timerpc
 from typing import Union
 
@@ -922,8 +921,9 @@ def get_dependent_turbines_by_wd(
                 (number of wind directions) x (number of turbines). Returned
                 only if return_influence_magnitudes is True.
     """
-    # Copy fi to a local to not mess with incoming
-    fm = copy.deepcopy(fm_in)
+    # Copy incoming ForisModel to modify locally. FlorisModel.copy() is used,
+    # which will not copy over stored wind_data or control setpoints.
+    fm = fm_in.copy()
 
     # Compute the base power
     fm.set(
@@ -943,8 +943,6 @@ def get_dependent_turbines_by_wd(
     fm.set(
         layout_x=np.delete(fm.layout_x, [test_turbine]),
         layout_y=np.delete(fm.layout_y, [test_turbine]),
-        wind_speeds=ws_test * np.ones_like(wd_array),
-        wind_directions=wd_array,
     )  # This will reindex the turbines; undone in following steps.
     fm.run()
     test_power = fm.get_turbine_powers()


### PR DESCRIPTION
As raised in #252 , there are various deprecations warnings raised based on our current requirements (in particular, from numpy and polars). This PR addresses those by fixing.

There seems to be some nuance about when/how deprecation warnings are raised. Simply running the examples as notebooks did not raise the warnings (for me). However, the following workflow works:
- Export the notebook to a python script
- Run the python script with the [`-Wd` flag](https://docs.python.org/3/library/warnings.html#updating-code-for-new-versions-of-dependencies), which explicitly raises deprecation warnings.

To do:
- [x] Address deprecation warnings raised in #252 
- [x] Address new FLORIS warnings raised, where possible
- [ ] Look through examples for other deprecation warnings using the workflow described above
- [ ] Address any other deprecation warnings that arise