### PR TITLE
Remove support for python 3.9 and add up to 3.14.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3"
 
     - name: Install dependencies
       run: |

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 Welcome to the documentation of the NLR FLASC repository!
 
 ```{note}
-As of FLASC v2.3, FLASC requires `numpy` version 2, following the update in FLORIS v4.3. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
+As of FLASC v2.5, FLASC requires python v3.10 or greater.
 ```
 
 FLASC provides a comprehensive toolkit for wind farm analysis, combining SCADA data processing with advanced wake modeling capabilities. The repository is intended as a community-driven toolbox, available on its [GitHub Repository](https://github.com/NatLabRockies/flasc).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "flasc"
 version = "2.4.2"
 description = "FLASC provides a rich suite of analysis tools for SCADA data filtering & analysis, wind farm model validation, field experiment design, and field experiment monitoring."
 readme = "README.md"
-requires-python = ">=3.10, <=3.14"
+requires-python = ">=3.10, <3.15"
 authors = [
     { name = "Paul Fleming", email = "paul.fleming@nlr.gov" },
     { name = "Michael (Misha) Sinner", email = "michael.sinner@nlr.gov" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "flasc"
 version = "2.4.2"
 description = "FLASC provides a rich suite of analysis tools for SCADA data filtering & analysis, wind farm model validation, field experiment design, and field experiment monitoring."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10, <=3.14"
 authors = [
     { name = "Paul Fleming", email = "paul.fleming@nlr.gov" },
     { name = "Michael (Misha) Sinner", email = "michael.sinner@nlr.gov" },


### PR DESCRIPTION
This PR removes support for python 3.9, which is at end of life, and adds support out to 3.14 (the latest version of python). See https://devguide.python.org/versions/

Testing of python 3.9 is removed and tests are added for 3.12, 3.13, and 3.14. A note is added to the docs landing page so that users are aware of the change.
